### PR TITLE
fix: preserve redacted thinking blocks during reasoning cleanup

### DIFF
--- a/packages/plugin/src/hooks/magic-context/strip-content.test.ts
+++ b/packages/plugin/src/hooks/magic-context/strip-content.test.ts
@@ -193,6 +193,26 @@ describe("strip-content", () => {
                 });
             });
         });
+
+        describe("#given assistant messages with redacted thinking parts", () => {
+            describe("#when stripping cleared reasoning", () => {
+                it("#then preserves redacted thinking blocks unchanged", () => {
+                    const redactedPart = {
+                        type: "redacted_thinking",
+                        data: "opaque-provider-payload",
+                    };
+                    const textPart = { type: "text", text: "visible response" };
+                    const msg = message("m-1", "assistant", [redactedPart, textPart]);
+
+                    const stripped = stripClearedReasoning([msg]);
+
+                    expect(stripped).toBe(0);
+                    expect(msg.parts).toHaveLength(2);
+                    expect(msg.parts[0]).toBe(redactedPart);
+                    expect(msg.parts[1]).toBe(textPart);
+                });
+            });
+        });
     });
 
     describe("stripInlineThinking", () => {

--- a/packages/plugin/src/hooks/magic-context/strip-content.ts
+++ b/packages/plugin/src/hooks/magic-context/strip-content.ts
@@ -279,7 +279,7 @@ function findMaxTag(messageTagNumbers: Map<MessageLike, number>): number {
     return max;
 }
 
-const CLEARED_REASONING_TYPES = new Set(["thinking", "reasoning", "redacted_thinking"]);
+const CLEARED_REASONING_TYPES = new Set(["thinking", "reasoning"]);
 
 export function stripClearedReasoning(messages: MessageLike[]): number {
     let stripped = 0;


### PR DESCRIPTION
## Summary
- stop `stripClearedReasoning()` from treating `redacted_thinking` as clearable reasoning content
- add a regression test proving assistant `redacted_thinking` blocks are preserved unchanged
- fixes #8

## Testing
- bun test packages/plugin/src/hooks/magic-context/strip-content.test.ts
- bun run typecheck