### PR TITLE
fix: strip all accumulated tags in stripTagPrefix to prevent tag accumulation

### DIFF
--- a/packages/plugin/src/hooks/magic-context/tag-content-primitives.ts
+++ b/packages/plugin/src/hooks/magic-context/tag-content-primitives.ts
@@ -1,7 +1,7 @@
 import type { ThinkingLikePart } from "./tag-messages";
 
 const encoder = new TextEncoder();
-const TAG_PREFIX_REGEX = /^§\d+§\s*/;
+const TAG_PREFIX_REGEX = /^(?:§\d+§\s*)+/;
 
 export function byteSize(value: string): number {
     return encoder.encode(value).length;


### PR DESCRIPTION
## Summary

Fixes tag accumulation bug where `stripTagPrefix` only removed a single tag, causing §N§ symbols to accumulate when content is processed multiple times during transform passes, compartment compaction, or message replay.

## Changes

Changed `TAG_PREFIX_REGEX` in `tag-content-primitives.ts`:

```typescript
// Before: Only matches ONE tag
const TAG_PREFIX_REGEX = /^§\d+§\s*/;

// After: Matches one or more consecutive tags  
const TAG_PREFIX_REGEX = /^(?:§\d+§\s*)+/;
```

## Problem

The original regex only stripped the outermost tag prefix, leaving previously accumulated tags intact. Each transform pass would prepend a new tag on top of old ones, resulting in unreadable messages like:

```
§4687§ §4686§ §4685§ ... actual content
```

## Solution

The new regex uses a non-capturing group with `+` quantifier to match **all** consecutive tag prefixes at the start of the string. This ensures `stripTagPrefix` removes all accumulated cruft before `prependTag` adds a single fresh tag.

## Testing

This change maintains backward compatibility - existing single-tag content works identically, and multi-tag content is now properly normalized to a single tag.

Fixes #11
