### PR TITLE
Add option for the notification interval

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -113,6 +113,7 @@ Higher-tier models with longer cache windows benefit from a longer TTL. Setting 
 | `ctx_reduce_enabled` | `boolean` | `true` | When `false`, hides `ctx_reduce` tool, disables all nudges/reminders, and strips reduction guidance from prompts. Heuristic cleanup, compartments, memory, and search still work. Useful for testing whether automatic cleanup alone is sufficient. |
 | `cache_ttl` | `string` or `object` | `"5m"` | Time after a response before applying pending ops. String or per-model map. |
 | `protected_tags` | `number` (1–100) | `20` | Last N active tags immune from immediate dropping. |
+| `toast_duration_ms` | `number` (1000–60000) | `5000` | TUI toast lifetime for Magic Context notifications in milliseconds. Increase this if toasts disappear too quickly. |
 | `execute_threshold_percentage` | `number` (20–80) or `object` | `65` | Context usage that forces queued ops to execute. Capped at 80% max for cache safety. Supports per-model map. |
 | `execute_threshold_tokens` | `object` (per-model map) | — | **Optional absolute-tokens variant of `execute_threshold_percentage`.** Per-model map (e.g. `{ "default": 150000, "github-copilot/gpt-5.2-codex": 40000 }`). When set for a model, overrides the percentage-based threshold for that model. Clamped to `80% × context_limit` with a warn log. Requires a resolvable context limit — falls through to percentage if unavailable. See below. |
 | `clear_reasoning_age` | `number` | `50` | Clear thinking/reasoning blocks older than N tags. |
@@ -626,6 +627,7 @@ Tier boundaries are hardcoded to keep behavior predictable and prevent cache-bus
     "anthropic/claude-opus-4-6": 50
   },
   "protected_tags": 10,
+  "toast_duration_ms": 12000,
   "history_budget_percentage": 0.15,
   "temporal_awareness": true,
 

--- a/assets/magic-context.schema.json
+++ b/assets/magic-context.schema.json
@@ -476,6 +476,13 @@
         }
       ]
     },
+    "toast_duration_ms": {
+      "default": 5000,
+      "description": "TUI toast lifetime in milliseconds for Magic Context notifications (min: 1000, max: 60000, default: 5000)",
+      "type": "number",
+      "minimum": 1000,
+      "maximum": 60000
+    },
     "execute_threshold_percentage": {
       "default": 65,
       "description": "Context percentage that forces queued operations to execute. Number or per-model object ({ default: 65, \"provider/model\": 45 }). Values above 80 are rejected because the runtime caps at 80% for cache safety (MAX_EXECUTE_THRESHOLD). Default: DEFAULT_EXECUTE_THRESHOLD_PERCENTAGE",

--- a/packages/dashboard/src/components/ConfigEditor/ConfigEditor.tsx
+++ b/packages/dashboard/src/components/ConfigEditor/ConfigEditor.tsx
@@ -204,6 +204,13 @@ const FIELD_DEFS: FieldDef[] = [
       "Enable agent-controlled reductions via the ctx_reduce tool. When enabled, the agent is prompted and nudged to choose what messages and tool calls to drop. When disabled, the system still manages context automatically via historian comparting and the tiered emergency drop under pressure.",
     section: "General",
   },
+  {
+    key: "toast_duration_ms",
+    label: "Toast Duration (ms)",
+    type: "number",
+    description: "How long Magic Context TUI toasts stay visible.",
+    section: "General",
+  },
   // Thresholds
   // cache_ttl and execute_threshold_percentage are rendered as custom PerModelField components
   // Tags & cleanup

--- a/packages/dashboard/src/components/ConfigEditor/config-field-coverage.ts
+++ b/packages/dashboard/src/components/ConfigEditor/config-field-coverage.ts
@@ -20,6 +20,7 @@ export const RENDERED_PREFIXES: readonly string[] = [
   // General
   "enabled",
   "ctx_reduce_enabled",
+  "toast_duration_ms",
   // Thresholds (custom PerModelField widgets)
   "cache_ttl",
   "execute_threshold_percentage",

--- a/packages/plugin/src/config/schema/magic-context.test.ts
+++ b/packages/plugin/src/config/schema/magic-context.test.ts
@@ -43,6 +43,7 @@ describe("MagicContextConfigSchema", () => {
                 enabled: true,
                 auto_update: false,
                 ctx_reduce_enabled: true,
+                toast_duration_ms: 5000,
                 cache_ttl: "10m",
                 protected_tags: 3,
                 execute_threshold_percentage: 75,

--- a/packages/plugin/src/config/schema/magic-context.ts
+++ b/packages/plugin/src/config/schema/magic-context.ts
@@ -258,6 +258,8 @@ export interface MagicContextConfig {
     historian?: HistorianConfig;
     dreamer?: DreamerConfig;
     cache_ttl: string | { default: string; [modelKey: string]: string };
+    /** TUI toast lifetime in milliseconds for Magic Context notifications. Default: 5000. */
+    toast_duration_ms?: number;
     execute_threshold_percentage: number | { default: number; [modelKey: string]: number };
     /** Absolute token thresholds per model. When set for a given model (or via `default`),
      *  this overrides `execute_threshold_percentage` for that model. Useful for hard caps
@@ -387,6 +389,14 @@ export const MagicContextConfigSchema = z
             .default("5m")
             .describe(
                 'Cache TTL: string (e.g. "5m") or per-model object ({ default: "5m", "model-id": "10m" })',
+            ),
+        toast_duration_ms: z
+            .number()
+            .min(1_000)
+            .max(60_000)
+            .default(5_000)
+            .describe(
+                "TUI toast lifetime in milliseconds for Magic Context notifications (min: 1000, max: 60000, default: 5000)",
             ),
         execute_threshold_percentage: z
             .union([

--- a/packages/plugin/src/hooks/magic-context/command-handler.test.ts
+++ b/packages/plugin/src/hooks/magic-context/command-handler.test.ts
@@ -690,13 +690,13 @@ describe("createMagicContextCommandHandler", () => {
                 1,
                 "ses-dream",
                 "Starting dream run...",
-                {},
+                { toastDurationMs: 5000 },
             );
             expect(sendNotification).toHaveBeenNthCalledWith(
                 2,
                 "ses-dream",
                 expect.stringContaining("### Tasks"),
-                {},
+                { toastDurationMs: 5000 },
             );
         });
 
@@ -744,7 +744,7 @@ describe("createMagicContextCommandHandler", () => {
                 3,
                 "ses-dream",
                 "Dream already queued for this project",
-                {},
+                { toastDurationMs: 5000 },
             );
             expect(executeDream).toHaveBeenCalledTimes(1);
         });

--- a/packages/plugin/src/hooks/magic-context/command-handler.ts
+++ b/packages/plugin/src/hooks/magic-context/command-handler.ts
@@ -270,6 +270,7 @@ async function executeDreaming(
             text: string,
             params: NotificationParams,
         ) => Promise<void>;
+        toastDurationMs?: number;
         dreamer?: {
             config: DreamerConfig;
             projectPath: string;
@@ -288,11 +289,15 @@ async function executeDreaming(
     },
     sessionId: string,
 ): Promise<never> {
+    const dreamNotificationParams: NotificationParams = {
+        toastDurationMs: deps.toastDurationMs ?? 5000,
+    };
+
     if (!deps.dreamer?.config?.tasks?.length) {
         await deps.sendNotification(
             sessionId,
             "## /ctx-dream\n\nDreaming is not configured for this project.",
-            {},
+            dreamNotificationParams,
         );
         throwSentinel("CTX-DREAM");
     }
@@ -303,11 +308,15 @@ async function executeDreaming(
     // runner with an unexpired lease is never deleted just because it is older than 2m.
     const entry = enqueueDream(deps.db, deps.dreamer.projectPath, "manual", true);
     if (!entry) {
-        await deps.sendNotification(sessionId, "Dream already queued for this project", {});
+        await deps.sendNotification(
+            sessionId,
+            "Dream already queued for this project",
+            dreamNotificationParams,
+        );
         throwSentinel("CTX-DREAM");
     }
 
-    await deps.sendNotification(sessionId, "Starting dream run...", {});
+    await deps.sendNotification(sessionId, "Starting dream run...", dreamNotificationParams);
 
     const result = deps.dreamer.executeDream
         ? await deps.dreamer.executeDream(sessionId)
@@ -334,7 +343,7 @@ async function executeDreaming(
         result
             ? summarizeDreamResult(result)
             : "Dream queued, but another worker is already processing the queue.",
-        {},
+        dreamNotificationParams,
     );
     throwSentinel("CTX-DREAM");
 }
@@ -373,6 +382,8 @@ export function createMagicContextCommandHandler(deps: {
         text: string,
         params: NotificationParams,
     ) => Promise<void>;
+    /** Configured toast lifetime (ms) forwarded into diagnostics logs. */
+    toastDurationMs?: number;
     sidekick?: {
         config: SidekickConfig;
         projectPath: string;

--- a/packages/plugin/src/hooks/magic-context/hook-handlers.ts
+++ b/packages/plugin/src/hooks/magic-context/hook-handlers.ts
@@ -130,11 +130,13 @@ export function getLiveNotificationParams(
     liveModelBySession: LiveModelBySession,
     variantBySession: VariantBySession,
     agentBySession?: AgentBySession,
+    toastDurationMs?: number,
 ): {
     agent?: string;
     variant?: string;
     providerId?: string;
     modelId?: string;
+    toastDurationMs?: number;
 } {
     const model = liveModelBySession.get(sessionId);
     const variant = variantBySession.get(sessionId);
@@ -143,6 +145,7 @@ export function getLiveNotificationParams(
         ...(agent ? { agent } : {}),
         ...(variant ? { variant } : {}),
         ...(model ? { providerId: model.providerID, modelId: model.modelID } : {}),
+        ...(typeof toastDurationMs === "number" ? { toastDurationMs } : {}),
     };
 }
 

--- a/packages/plugin/src/hooks/magic-context/hook.ts
+++ b/packages/plugin/src/hooks/magic-context/hook.ts
@@ -92,6 +92,7 @@ export interface MagicContextDeps {
     config: {
         protected_tags: number;
         ctx_reduce_enabled?: boolean;
+        toast_duration_ms?: number;
         clear_reasoning_age?: number;
         execute_threshold_percentage?: number | { default: number; [modelKey: string]: number };
         execute_threshold_tokens?: { default?: number; [modelKey: string]: number | undefined };
@@ -343,7 +344,13 @@ export function createMagicContextHook(deps: MagicContextDeps) {
         userMemoriesEnabled: dreamerConfig?.user_memories?.enabled === true,
         ensureProjectRegistered: ensureProjectRegisteredFromOpenCodeDirectory,
         getNotificationParams: (sid) =>
-            getLiveNotificationParams(sid, liveModelBySession, variantBySession, agentBySession),
+            getLiveNotificationParams(
+                sid,
+                liveModelBySession,
+                variantBySession,
+                agentBySession,
+                deps.config.toast_duration_ms,
+            ),
     });
     // /ctx-embed start: backfill THIS session's compartment chunk embeddings,
     // reusing the recomp progress surface (sidebar + status bar) with kind="embed".
@@ -561,6 +568,7 @@ export function createMagicContextHook(deps: MagicContextDeps) {
                 liveModelBySession,
                 variantBySession,
                 agentBySession,
+                deps.config.toast_duration_ms,
             ),
         getModelKey: (sessionId) => {
             const model = liveModelBySession.get(sessionId);
@@ -618,6 +626,7 @@ export function createMagicContextHook(deps: MagicContextDeps) {
                 liveModelBySession,
                 variantBySession,
                 agentBySession,
+                deps.config.toast_duration_ms,
             ),
         onSessionCacheInvalidated: (sessionId: string) => {
             clearInjectionCache(sessionId);
@@ -698,6 +707,7 @@ export function createMagicContextHook(deps: MagicContextDeps) {
     const commandHandler = createMagicContextCommandHandler({
         db,
         protectedTags: deps.config.protected_tags,
+        toastDurationMs: deps.config.toast_duration_ms,
         executeThresholdPercentage: deps.config.execute_threshold_percentage ?? 65,
         executeThresholdTokens: deps.config.execute_threshold_tokens,
         historyBudgetPercentage: deps.config.history_budget_percentage,
@@ -751,6 +761,7 @@ export function createMagicContextHook(deps: MagicContextDeps) {
                     liveModelBySession,
                     variantBySession,
                     agentBySession,
+                    deps.config.toast_duration_ms,
                 ),
                 ...params,
             });
@@ -872,6 +883,7 @@ export function createMagicContextHook(deps: MagicContextDeps) {
                                       liveModelBySession,
                                       variantBySession,
                                       agentBySession,
+                                      deps.config.toast_duration_ms,
                                   ),
                               isTuiConnected,
                               pushTuiDialogAction: (sid, resume) =>

--- a/packages/plugin/src/hooks/magic-context/send-session-notification.ts
+++ b/packages/plugin/src/hooks/magic-context/send-session-notification.ts
@@ -6,6 +6,8 @@ export interface NotificationParams {
     variant?: string;
     providerId?: string;
     modelId?: string;
+    /** TUI toast lifetime in milliseconds (default: 5000). */
+    toastDurationMs?: number;
 }
 
 export type NotificationDeliveryDisposition = "sent" | "skipped" | "failed";
@@ -71,31 +73,32 @@ export async function sendIgnoredMessage(
     // is too easy to miss — dogfood 2026-05-30.
     forcePersist = false,
 ): Promise<NotificationDeliveryDisposition> {
+    const title = extractToastTitle(text);
+    const message = text.length > 200 ? `${text.slice(0, 200)}…` : text;
+    const toastVariant = inferToastVariant(text);
+    const duration = params.toastDurationMs ?? 5000;
+
     // In TUI mode, show as toast via RPC instead of ignored message — UNLESS the
     // caller asked to force-persist (long-running outcome must stay in scrollback).
     // Cannot use process.env.OPENCODE_CLIENT — it's undefined in the server plugin process.
     const { isTuiConnected: checkTui } = await import("../../shared/rpc-notifications");
     if (!forcePersist && checkTui(sessionId)) {
         try {
-            const c = client as Record<string, unknown>;
-            const tui = c?.tui as Record<string, unknown> | undefined;
-            if (typeof tui?.showToast === "function") {
-                // Intentional: call via property access to preserve `this` binding on the SDK client.
-                // The tui object is an SDK-generated client where methods live on the prototype.
-                const tuiClient = tui as Record<string, (...args: unknown[]) => Promise<unknown>>;
-                await tuiClient.showToast({
-                    body: {
-                        title: extractToastTitle(text),
-                        message: text.length > 200 ? `${text.slice(0, 200)}…` : text,
-                        variant: inferToastVariant(text),
-                        duration: 5000,
-                    },
-                });
-                return "sent";
-            }
+            const { pushNotification } = await import("../../shared/rpc-notifications");
+            pushNotification(
+                "toast",
+                {
+                    title,
+                    message,
+                    variant: toastVariant,
+                    duration,
+                },
+                sessionId,
+            );
+            return "sent";
         } catch {
-            // showToast failed or tui client is unavailable — fall through to ignored message.
-            sessionLog(sessionId, "TUI showToast failed, falling back to ignored message");
+            // RPC enqueue failed — fall through to ignored message.
+            sessionLog(sessionId, "TUI RPC toast enqueue failed, falling back to ignored message");
         }
     }
     // Title-safety guard (issue #129): an ignored message is hidden from the

--- a/packages/plugin/src/plugin/hooks/create-session-hooks.test.ts
+++ b/packages/plugin/src/plugin/hooks/create-session-hooks.test.ts
@@ -1,0 +1,43 @@
+/// <reference types="bun-types" />
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const createMagicContextHookMock = mock(() => ({ mocked: true }));
+
+mock.module("../../hooks/magic-context", () => ({
+    createMagicContextHook: createMagicContextHookMock,
+}));
+
+describe("createSessionHooks", () => {
+    beforeEach(() => {
+        createMagicContextHookMock.mockClear();
+    });
+
+    it("threads notification config into the magic-context hook", async () => {
+        const { createSessionHooks } = await import("./create-session-hooks");
+
+        createSessionHooks({
+            ctx: {
+                client: {},
+                directory: "/tmp/project",
+            } as never,
+            liveSessionState: {
+                liveModelBySession: new Map(),
+                variantBySession: new Map(),
+                agentBySession: new Map(),
+            },
+            pluginConfig: {
+                enabled: true,
+                protected_tags: 10,
+                cache_ttl: "5m",
+                toast_duration_ms: 30_000,
+            } as never,
+        });
+
+        expect(createMagicContextHookMock).toHaveBeenCalledTimes(1);
+        const args = createMagicContextHookMock.mock.calls[0]?.[0] as {
+            config?: { toast_duration_ms?: number };
+        };
+        expect(args.config?.toast_duration_ms).toBe(30_000);
+    });
+});

--- a/packages/plugin/src/plugin/hooks/create-session-hooks.ts
+++ b/packages/plugin/src/plugin/hooks/create-session-hooks.ts
@@ -44,6 +44,7 @@ export function createSessionHooks(args: {
                 ctx_reduce_enabled: pluginConfig.ctx_reduce_enabled,
                 cache_ttl: pluginConfig.cache_ttl,
                 clear_reasoning_age: pluginConfig.clear_reasoning_age,
+                toast_duration_ms: pluginConfig.toast_duration_ms,
                 execute_threshold_percentage:
                     pluginConfig.execute_threshold_percentage ??
                     DEFAULT_EXECUTE_THRESHOLD_PERCENTAGE,

--- a/packages/plugin/src/plugin/rpc-handlers.ts
+++ b/packages/plugin/src/plugin/rpc-handlers.ts
@@ -535,6 +535,7 @@ export function buildStatusDetail(
         historyBlockTokens: 0,
         compressionBudget: null,
         compressionUsage: null,
+        toastDurationMs: 5000,
     };
 
     try {
@@ -628,6 +629,12 @@ export function buildStatusDetail(
             if (typeof config.history_budget_percentage === "number") {
                 detail.historyBudgetPercentage = config.history_budget_percentage;
             }
+            detail.toastDurationMs = resolveConfigValue<number>(
+                config,
+                "toast_duration_ms",
+                modelKey,
+                5000,
+            );
         }
 
         // Derived values
@@ -715,6 +722,7 @@ export function registerRpcHandlers(
             liveSessionState.liveModelBySession,
             liveSessionState.variantBySession,
             liveSessionState.agentBySession,
+            config.toast_duration_ms,
         );
 
     const injectionBudgetTokens = config.memory?.injection_budget_tokens;
@@ -895,6 +903,15 @@ export function registerRpcHandlers(
             log("[rpc] dismiss-upgrade-reminder failed:", error);
             return { ok: false, error: String(error) };
         }
+    });
+
+    rpcServer.handle("toast-duration", async () => {
+        const resolved =
+            typeof config.toast_duration_ms === "number" &&
+            Number.isFinite(config.toast_duration_ms)
+                ? config.toast_duration_ms
+                : 5000;
+        return { toastDurationMs: resolved };
     });
 
     rpcServer.handle("pending-notifications", async (params) => {

--- a/packages/plugin/src/shared/rpc-types.ts
+++ b/packages/plugin/src/shared/rpc-types.ts
@@ -121,6 +121,8 @@ export interface StatusDetail extends SidebarSnapshot {
     historyBlockTokens: number;
     compressionBudget: number | null;
     compressionUsage: string | null;
+    /** Effective configured toast duration in ms after config resolution. */
+    toastDurationMs: number;
 }
 
 /** Embedding coverage for `/ctx-embed` status (mirrors getEmbeddingCoverageStatus). */

--- a/packages/plugin/src/tui/data/context-db.ts
+++ b/packages/plugin/src/tui/data/context-db.ts
@@ -205,6 +205,7 @@ export async function loadStatusDetail(
         historyBlockTokens: 0,
         compressionBudget: null,
         compressionUsage: null,
+        toastDurationMs: 5000,
     };
 
     if (!rpcClient) return emptyDetail;
@@ -296,6 +297,17 @@ export async function dismissUpgradeReminder(sessionId: string): Promise<boolean
         return result.ok ?? false;
     } catch {
         return false;
+    }
+}
+
+/** Resolve global toast duration from server config via RPC. */
+export async function loadToastDurationMs(): Promise<number> {
+    if (!rpcClient) return 5000;
+    try {
+        const result = await rpcClient.call<{ toastDurationMs?: number }>("toast-duration", {});
+        return typeof result.toastDurationMs === "number" ? result.toastDurationMs : 5000;
+    } catch {
+        return 5000;
     }
 }
 

--- a/packages/plugin/src/tui/index.tsx
+++ b/packages/plugin/src/tui/index.tsx
@@ -6,7 +6,7 @@ import { createMemo } from "solid-js"
 import type { TuiPlugin, TuiPluginApi, TuiThemeCurrent } from "@opencode-ai/plugin/tui"
 import { createSidebarContentSlot, kickRecompProgressRefresh } from "./slots/sidebar-content"
 import packageJson from "../../package.json"
-import { closeRpc, consumeTuiMessages, dismissUpgradeReminder, getAnnouncement, getCompartmentCount, getRpcGeneration, initRpcClient, loadEmbedDetail, loadStatusDetail, markAnnounced, markTuiMessagesHandled, requestRecomp, requestUpgrade, type EmbedDetail, type TuiMessage, type StatusDetail } from "./data/context-db"
+import { closeRpc, consumeTuiMessages, dismissUpgradeReminder, getAnnouncement, getCompartmentCount, getRpcGeneration, initRpcClient, loadEmbedDetail, loadStatusDetail, loadToastDurationMs, markAnnounced, markTuiMessagesHandled, requestRecomp, requestUpgrade, type EmbedDetail, type TuiMessage, type StatusDetail } from "./data/context-db"
 import { formatThresholdPercent } from "../shared/format-threshold"
 import { detectConflicts } from "../shared/conflict-detector"
 import { fixConflicts } from "../shared/conflict-fixer"
@@ -14,6 +14,42 @@ import { readJsoncFile } from "../shared/jsonc-parser"
 import { getOpenCodeConfigPaths } from "../shared/opencode-config-dir"
 
 const PLUGIN_NAME = "@cortexkit/opencode-magic-context"
+const DEFAULT_TOAST_DURATION_MS = 5000
+let unifiedToastDurationMs = DEFAULT_TOAST_DURATION_MS
+
+async function refreshToastDurationMs(): Promise<void> {
+    try {
+        const resolved = await loadToastDurationMs()
+        if (typeof resolved === "number" && Number.isFinite(resolved)) {
+            unifiedToastDurationMs = resolved
+        }
+    } catch {
+        // Keep the current value; the next poll/startup can retry.
+    }
+}
+
+function getToastDurationMs(): number {
+    return unifiedToastDurationMs
+}
+
+function showToast(
+    api: TuiPluginApi,
+    input: {
+        message: string
+        variant: "info" | "warning" | "error" | "success"
+        durationOverrideMs?: number
+    },
+): void {
+    const duration =
+        typeof input.durationOverrideMs === "number" && Number.isFinite(input.durationOverrideMs)
+            ? input.durationOverrideMs
+            : getToastDurationMs()
+    api.ui.toast({
+        message: input.message,
+        variant: input.variant,
+        duration,
+    })
+}
 
 function ensureParentDir(filePath: string) {
     mkdirSync(dirname(filePath), { recursive: true })
@@ -97,14 +133,18 @@ function showConflictDialog(api: TuiPluginApi, directory: string, reasons: strin
                             title="✅ Configuration Fixed"
                             message={`${actionSummary}\n\nPlease restart OpenCode for changes to take effect.`}
                             onConfirm={() => {
-                                api.ui.toast({ message: "Restart OpenCode to enable Magic Context", variant: "warning", duration: 10000 })
+                                showToast(api, {
+                                    message: "Restart OpenCode to enable Magic Context",
+                                    variant: "warning",
+                                    durationOverrideMs: 10_000,
+                                })
                             }}
                         />
                     ))
                 }, 50)
             }}
             onCancel={() => {
-                api.ui.toast({ message: "Magic Context remains disabled. Run: npx @cortexkit/opencode-magic-context@latest doctor", variant: "warning", duration: 5000 })
+                showToast(api, { message: "Magic Context remains disabled. Run: npx @cortexkit/opencode-magic-context@latest doctor", variant: "warning" })
             }}
         />
     ))
@@ -132,7 +172,7 @@ function showTuiSetupDialog(api: TuiPluginApi) {
                                 title="❌ Setup Failed"
                                 message={'Could not update tui.json automatically. Add the plugin manually:\n\n  { "plugin": ["@cortexkit/opencode-magic-context"] }'}
                                 onConfirm={() => {
-                                    api.ui.toast({ message: "Add plugin to tui.json manually", variant: "warning", duration: 5000 })
+                                    showToast(api, { message: "Add plugin to tui.json manually", variant: "warning" })
                                 }}
                             />
                         ))
@@ -146,14 +186,18 @@ function showTuiSetupDialog(api: TuiPluginApi) {
                             title="✅ Sidebar Enabled"
                             message="tui.json updated with Magic Context plugin.\n\nPlease restart OpenCode to see the sidebar."
                             onConfirm={() => {
-                                api.ui.toast({ message: "Restart OpenCode to see the sidebar", variant: "warning", duration: 10000 })
+                                showToast(api, {
+                                    message: "Restart OpenCode to see the sidebar",
+                                    variant: "warning",
+                                    durationOverrideMs: 10_000,
+                                })
                             }}
                         />
                     ))
                 }, 50)
             }}
             onCancel={() => {
-                api.ui.toast({ message: "You can add the sidebar later via: npx @cortexkit/opencode-magic-context@latest doctor", variant: "info", duration: 5000 })
+                showToast(api, { message: "You can add the sidebar later via: npx @cortexkit/opencode-magic-context@latest doctor", variant: "info" })
             }}
         />
     ))
@@ -458,7 +502,7 @@ function getModelKeyFromMessages(api: TuiPluginApi, sessionId: string): string |
 async function showRecompDialog(api: TuiPluginApi, targetSessionId = getSessionId(api)): Promise<boolean> {
     const sessionId = targetSessionId
     if (!sessionId) {
-        api.ui.toast({ message: "No active session", variant: "warning" })
+        showToast(api, { message: "No active session", variant: "warning" })
         return false
     }
 
@@ -483,10 +527,10 @@ async function showRecompDialog(api: TuiPluginApi, targetSessionId = getSessionI
             onConfirm={() => {
                 void requestRecomp(sessionId)
                 kickRecompProgressRefresh()
-                api.ui.toast({ message: "Recomp requested — historian will start shortly", variant: "info", duration: 5000 })
+                showToast(api, { message: "Recomp requested — historian will start shortly", variant: "info" })
             }}
             onCancel={() => {
-                api.ui.toast({ message: "Recomp cancelled", variant: "info", duration: 3000 })
+                showToast(api, { message: "Recomp cancelled", variant: "info", durationOverrideMs: 3000 })
             }}
         />
     ))
@@ -543,12 +587,11 @@ function showUpgradeDialog(
                     // call fires no message event, so without this the progress
                     // bar wouldn't appear until the upgrade finished.
                     kickRecompProgressRefresh()
-                    api.ui.toast({
+                    showToast(api, {
                         message: resume
                             ? "Resuming session upgrade — running in the background"
                             : "Session upgrade started — running in the background",
                         variant: "info",
-                        duration: 5000,
                     })
                     // Dismiss the durable reminder ONLY after the upgrade request
                     // actually started. If requestUpgrade() returns false (RPC /
@@ -566,10 +609,10 @@ function showUpgradeDialog(
                     // never-upgraded session (dogfood 2026-05-30) relies on THIS
                     // being the only place the TUI path stamps.
                     void dismissUpgradeReminder(sessionId)
-                    api.ui.toast({
+                    showToast(api, {
                         message: "Upgrade skipped — run /ctx-session-upgrade anytime",
                         variant: "info",
-                        duration: 4000,
+                        durationOverrideMs: 4000,
                     })
                 }}
             />
@@ -581,7 +624,7 @@ function showUpgradeDialog(
 async function showStatusDialog(api: TuiPluginApi, targetSessionId = getSessionId(api)): Promise<boolean> {
     const sessionId = targetSessionId
     if (!sessionId) {
-        api.ui.toast({ message: "No active session", variant: "warning" })
+        showToast(api, { message: "No active session", variant: "warning" })
         return false
     }
 
@@ -801,6 +844,7 @@ const tui: TuiPlugin = async (api, _options, meta) => {
     // Initialize RPC client for server communication
     const directory = api.state.path.directory ?? ""
     initRpcClient(directory)
+    await refreshToastDurationMs()
 
     // Register sidebar slot
     api.slots.register(createSidebarContentSlot(api))
@@ -838,6 +882,9 @@ const tui: TuiPlugin = async (api, _options, meta) => {
         pollInFlight = true
         const pollGeneration = getRpcGeneration()
         void consumeTuiMessages(requestedSessionId).then(async (messages) => {
+            if (unifiedToastDurationMs === DEFAULT_TOAST_DURATION_MS) {
+                void refreshToastDurationMs()
+            }
             // The dialog handlers read the current session when they run. If the
             // user switched routes while the RPC was in flight, drop this whole
             // batch without advancing the cursor; the next poll for the new
@@ -868,10 +915,13 @@ const tui: TuiPlugin = async (api, _options, meta) => {
                 }
                 if (msg.type === "toast") {
                     const p = msg.payload
-                    api.ui.toast({
+                    showToast(api, {
                         message: String(p.message ?? ""),
                         variant: (p.variant as "info" | "warning" | "error" | "success") ?? "info",
-                        duration: typeof p.duration === "number" ? p.duration : 5000,
+                        durationOverrideMs:
+                            typeof p.duration === "number" && Number.isFinite(p.duration)
+                                ? p.duration
+                                : undefined,
                     })
                     handledMessageIds.add(msg.id)
                 } else if (msg.type === "action") {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable toast duration for Magic Context notifications and threads it end-to-end from config to the TUI. The TUI loads it via a new `toast-duration` RPC and uses a unified toast helper; dream, status, setup, and restart toasts respect the setting, with 10s overrides for setup/restart.

- **New Features**
  - Added `toast_duration_ms` to config/schema (1000–60000, default 5000ms); documented and exposed in the Dashboard Config Editor.
  - New `toast-duration` RPC; the TUI fetches and caches it on startup and uses a unified `showToast` with per-toast overrides.
  - `NotificationParams` and `StatusDetail` carry `toastDurationMs`; server notifications are queued via RPC and respect the duration.

- **Bug Fixes**
  - Preserved `toast_duration_ms` in `createSessionHooks` and threaded it through `getLiveNotificationParams` and command handlers so dream notifications use the configured duration; added regression test.

<sup>Written for commit 2f8d5fbef09e6179f1f857efe31a3c7faed95673. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a configurable `toast_duration_ms` setting (1000–60000 ms, default 5000 ms) for Magic Context TUI notifications. The config is validated via Zod, exposed in the Dashboard Config Editor and `CONFIGURATION.md`, fetched by the TUI on startup via a new `toast-duration` RPC, and threaded through `NotificationParams` so server-side notifications (dream, recomp outcomes) respect the configured duration.

- **New RPC endpoint** `toast-duration` lets the TUI fetch and cache `toast_duration_ms` on startup; a unified `showToast` helper uses the cached value with per-call override support (`durationOverrideMs`).
- **`create-session-hooks.ts`** now passes `toast_duration_ms` into the magic-context hook config so `/ctx-dream` notifications use the configured duration instead of always falling back to 5 s; a regression test covers this.
- **Restart-required toasts** correctly carry `durationOverrideMs: 10_000`, matching the intent called out in the previous review round.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the polling retry loop; all core notification paths behave correctly.

The 500 ms message poller fires refreshToastDurationMs() on every tick when the toast duration equals the default value. Because 5000 ms is both the configured default and the error-path fallback, this condition is permanently true for any user who has not overridden the setting — the overwhelming majority. Everything else in the PR (schema, RPC handler, dream notification threading, restart-toast overrides) is straightforward and correct.

packages/plugin/src/tui/index.tsx — the poller's retry guard at line 838

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/plugin/src/tui/index.tsx | Adds showToast helper, loadToastDurationMs on startup, and unified duration; restart toasts correctly carry durationOverrideMs: 10_000 — but the poller's retry guard fires every 500ms for default-config users |
| packages/plugin/src/plugin/rpc-handlers.ts | Adds toast-duration RPC handler and populates StatusDetail.toastDurationMs; the toastDurationMs field on StatusDetail is computed and transported but never read by any TUI consumer |
| packages/plugin/src/hooks/magic-context/command-handler.ts | Adds toastDurationMs to executeDreaming deps and dreamNotificationParams; correctly threads config value from createMagicContextCommandHandler |
| packages/plugin/src/plugin/hooks/create-session-hooks.ts | Threads toast_duration_ms from pluginConfig into the magic-context hook config; regression test added |
| packages/plugin/src/shared/rpc-types.ts | Adds toastDurationMs field to StatusDetail type with correct documentation |
| packages/plugin/src/tui/data/context-db.ts | Adds loadToastDurationMs() RPC helper; clean implementation with safe fallback |

</details>

</details>

<sub>Reviews (9): Last reviewed commit: ["fix: thread toast duration through sessi..."](https://github.com/cortexkit/magic-context/commit/21db026d171380d59e7ebff4bb5ae0ed01e0ff02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35109384)</sub>

<!-- /greptile_comment -->