### PR TITLE
feat(tui): collapsible sidebar with compact usage overview

### DIFF
--- a/assets/magic-context.schema.json
+++ b/assets/magic-context.schema.json
@@ -778,6 +778,69 @@
       "additionalProperties": false,
       "description": "Cross-session memory configuration"
     },
+    "tui": {
+      "description": "TUI sidebar and status dialog configuration",
+      "type": "object",
+      "properties": {
+        "sidebar": {
+          "description": "Sidebar panel defaults (manual toggle state is persisted via KV and overrides these)",
+          "type": "object",
+          "properties": {
+            "collapse_default": {
+              "description": "Start with the sidebar collapsed on new sessions. The manual toggle is still persisted across restarts via KV, so once a user toggles, that state is respected regardless of this default.",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "additionalProperties": false,
+          "default": {
+            "collapse_default": false
+          }
+        },
+        "compact_bar": {
+          "description": "Token usage bar in collapsed sidebar mode",
+          "type": "object",
+          "properties": {
+            "label_threshold": {
+              "description": "Minimum segment share (0-1) to show the token-count label on a non-free segment. Higher values reduce label clutter on narrow segments. At the default 0.10 (10%), 4-char labels like '351K' fit a 4+ wide segment.",
+              "type": "number",
+              "minimum": 0.05,
+              "maximum": 0.50,
+              "default": 0.10
+            },
+            "free_label_threshold": {
+              "description": "Minimum segment share (0-1) to show the full 'XXK Free' label on the last (free-context) segment. Below this, the short number-only label is shown instead. The default 0.25 (25%) gives room for the longest possible label (9 chars, e.g. '351K Free') on a 36+ char sidebar. Narrower sidebars show just '351K'.",
+              "type": "number",
+              "minimum": 0.10,
+              "maximum": 0.50,
+              "default": 0.25
+            },
+            "show_free_label": {
+              "description": "Whether to append ' Free' to the last segment label. When false, only the token count is shown on the free segment regardless of segment width.",
+              "type": "boolean",
+              "default": true
+            }
+          },
+          "additionalProperties": false,
+          "default": {
+            "label_threshold": 0.10,
+            "free_label_threshold": 0.25,
+            "show_free_label": true
+          }
+        }
+      },
+      "additionalProperties": false,
+      "default": {
+        "sidebar": {
+          "collapse_default": false
+        },
+        "compact_bar": {
+          "label_threshold": 0.10,
+          "free_label_threshold": 0.25,
+          "show_free_label": true
+        }
+      }
+    },
     "sidekick": {
       "type": "object",
       "properties": {

--- a/packages/plugin/src/tui/slots/sidebar-content.tsx
+++ b/packages/plugin/src/tui/slots/sidebar-content.tsx
@@ -1,18 +1,12 @@
 /** @jsxImportSource @opentui/solid */
-import { createEffect, createMemo, createSignal, on, onCleanup } from "solid-js"
+import { createEffect, createMemo, createSignal, on, onCleanup, Show } from "solid-js"
 import type { TuiSlotPlugin, TuiPluginApi, TuiThemeCurrent } from "@opencode-ai/plugin/tui"
 import packageJson from "../../../package.json"
 import { loadSidebarSnapshot, type SidebarSnapshot } from "../data/context-db"
-import { formatThresholdPercent } from "../../shared/format-threshold"
+import { compactTokens, collapsedStatusLine, formatThresholdPercent } from "./sidebar-utils"
 
 const SINGLE_BORDER = { type: "single" } as any
 const REFRESH_DEBOUNCE_MS = 150
-
-function compactTokens(value: number): string {
-    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
-    if (value >= 1_000) return `${(value / 1_000).toFixed(0)}K`
-    return String(value)
-}
 
 function relativeTime(ms: number): string {
     const diff = Date.now() - ms
@@ -34,6 +28,9 @@ const COLORS = {
     conversation: "#f87171", // Red
     toolCalls: "#fb923c", // Orange
     toolDefs: "#f472b6", // Pink
+    // Unused / free — dim, distinct from usage segments.
+    // Appears only in the collapsed bar when contextLimit > inputTokens.
+    free: "#666666", // Dim gray
 }
 
 interface TokenSegment {
@@ -47,6 +44,7 @@ interface TokenSegment {
 const TokenBreakdown = (props: {
     theme: TuiThemeCurrent
     snapshot: SidebarSnapshot
+    compact?: boolean
 }) => {
     // The bar is rendered as a flex row of colored boxes, each with
     // flexGrow=tokens and flexBasis=0. opentui distributes the parent
@@ -143,10 +141,28 @@ const TokenBreakdown = (props: {
             })
         }
 
+        // Free remaining context — shown only in compact mode so the bar
+        // fills the full contextLimit width and labels show "64K Free" etc.
+        if (props.compact && s.contextLimit && s.contextLimit > s.inputTokens) {
+            result.push({
+                key: "free",
+                tokens: s.contextLimit - s.inputTokens,
+                color: COLORS.free,
+                label: "Free",
+            })
+        }
+
         return result
     })
 
-    const totalTokens = createMemo(() => props.snapshot.inputTokens || 1)
+    // In compact mode with Free segment, the total is the full context limit
+    // so the Free segment gets its proportional share of the bar width.
+    const totalTokens = createMemo(() => {
+        if (props.compact && props.snapshot.contextLimit && props.snapshot.contextLimit > props.snapshot.inputTokens) {
+            return props.snapshot.contextLimit
+        }
+        return props.snapshot.inputTokens || 1
+    })
 
     // Render-time segments for the bar. Zero-token segments are filtered out
     // entirely (no flex weight, no rendered box) so they don't claim any
@@ -160,25 +176,68 @@ const TokenBreakdown = (props: {
 
     return (
         <box width="100%" flexDirection="column">
-            {/* Segmented bar: a width="100%" flex row of colored boxes,
-                each with flexGrow proportional to its token count and
-                flexBasis=0. opentui distributes the parent's full width
-                proportionally, so the bar always fills the sidebar
-                regardless of terminal size. Height is fixed at 1 row;
-                backgroundColor renders the colored bar. */}
+            {/* Segmented bar: flex row of colored boxes, each with flexGrow
+                proportional to its token count and flexBasis=0. opentui
+                distributes the parent's full width proportionally so the bar
+                always fills the sidebar. In compact mode, wide-enough segments
+                show token-count labels centered over their colored box. */}
             <box width="100%" flexDirection="row" height={1}>
-                {barSegments().map((seg) => (
-                    <box
-                        key={seg.key}
-                        flexGrow={Math.max(1, seg.tokens)}
-                        flexBasis={0}
-                        height={1}
-                        backgroundColor={seg.color}
-                    />
-                ))}
+                {(props.compact ? barSegments() : barSegments()).map((seg) => {
+                    // In compact mode, overlay a label when the segment is
+                    // wide enough (≥8% of the total). Free segments get the
+                    // "XXK Free" label at ≥12% to accommodate the longer text.
+                    const pct = seg.tokens / totalTokens()
+                    const showLabel = props.compact && pct >= 0.08 && seg.key !== "free"
+                    const showFreeLabel = props.compact && seg.key === "free" && pct >= 0.12
+
+                    if (showFreeLabel) {
+                        return (
+                            <box
+                                key={seg.key}
+                                flexGrow={Math.max(1, seg.tokens)}
+                                flexBasis={0}
+                                height={1}
+                                backgroundColor={seg.color}
+                                flexDirection="row"
+                                alignItems="center"
+                                justifyContent="center"
+                            >
+                                <text fg={props.theme.background}>{`${compactTokens(seg.tokens)} Free`}</text>
+                            </box>
+                        )
+                    }
+
+                    if (showLabel) {
+                        return (
+                            <box
+                                key={seg.key}
+                                flexGrow={Math.max(1, seg.tokens)}
+                                flexBasis={0}
+                                height={1}
+                                backgroundColor={seg.color}
+                                flexDirection="row"
+                                alignItems="center"
+                                justifyContent="center"
+                            >
+                                <text fg={props.theme.background}>{compactTokens(seg.tokens)}</text>
+                            </box>
+                        )
+                    }
+
+                    return (
+                        <box
+                            key={seg.key}
+                            flexGrow={Math.max(1, seg.tokens)}
+                            flexBasis={0}
+                            height={1}
+                            backgroundColor={seg.color}
+                        />
+                    )
+                })}
             </box>
 
-            {/* Legend rows */}
+            {/* Legend rows — hidden in compact mode */}
+            {!props.compact && (
             <box flexDirection="column" marginTop={0}>
                 {segments().map((seg) => {
                     const pct = ((seg.tokens / totalTokens()) * 100).toFixed(0)
@@ -197,6 +256,7 @@ const TokenBreakdown = (props: {
                     )
                 })}
             </box>
+            )}
         </box>
     )
 }
@@ -311,6 +371,19 @@ const SidebarContent = (props: {
         return props.theme.accent
     })
 
+    // Collapse state persisted via KV (survives restarts)
+    const COLLAPSED_KV_KEY = "mc-sidebar-collapsed"
+    const [collapsed, setCollapsed] = createSignal(
+        props.api.kv.get(COLLAPSED_KV_KEY, false) as boolean,
+    )
+    createEffect(() => {
+        props.api.kv.set(COLLAPSED_KV_KEY, collapsed())
+    })
+    const toggle = () => setCollapsed((x) => !x)
+
+    // Status line for collapsed view (line 3)
+    const collapsedStatusLineMemo = createMemo(() => collapsedStatusLine(s()))
+
     return (
         <box
             width="100%"
@@ -322,143 +395,169 @@ const SidebarContent = (props: {
             paddingLeft={1}
             paddingRight={1}
         >
-            {/* Header */}
-            <box flexDirection="row" justifyContent="space-between" alignItems="center">
-                <box paddingLeft={1} paddingRight={1} backgroundColor={props.theme.accent}>
-                    <text fg={props.theme.background}>
-                        <b>Magic Context</b>
-                    </text>
+            {/* Toggle header — collapsed shows compact usage, expanded shows brand */}
+            <Show when={collapsed()} fallback={
+                <box flexDirection="row" justifyContent="space-between" alignItems="center" onMouseDown={toggle}>
+                    <box paddingLeft={1} paddingRight={1} backgroundColor={props.theme.accent}>
+                        <text fg={props.theme.background}>
+                            <b>▼ Magic Context</b>
+                        </text>
+                    </box>
+                    <text fg={props.theme.textMuted}>v{packageJson.version}</text>
                 </box>
-                <text fg={props.theme.textMuted}>v{packageJson.version}</text>
-            </box>
+            }>
+                <Show when={s() && s()!.inputTokens > 0 && (s()?.contextLimit ?? 0) > 0} fallback={
+                    <box flexDirection="row" onMouseDown={toggle}>
+                        <text fg={props.theme.textMuted}>▶ Magic Context</text>
+                    </box>
+                }>
+                    <box flexDirection="row" width="100%" justifyContent="space-between" onMouseDown={toggle}>
+                        <text fg={contextSummaryColor()}>
+                            <b>▶</b> {s()!.usagePercentage.toFixed(1)}% / {formatThresholdPercent(s()!.executeThreshold)}%
+                        </text>
+                        <text fg={contextSummaryColor()}>
+                            {compactTokens(s()!.inputTokens)} / {compactTokens(s()!.contextLimit)}
+                        </text>
+                    </box>
+                </Show>
+            </Show>
 
-            {/* Token breakdown bar */}
-            {s() && s()!.inputTokens > 0 && (
-                <box marginTop={1} flexDirection="column">
-                    {(s()?.contextLimit ?? 0) > 0 && (
-                        <box width="100%" flexDirection="row" justifyContent="space-between">
-                            {/* Left: current usage vs the per-model execute
-                                threshold (the value Magic Context compares
-                                against when scheduling historian / drops).
-                                "47.5% / 65%" tells the user how close they
-                                are to the next compaction trigger. */}
-                            <text fg={contextSummaryColor()}>
-                                <b>{s()!.usagePercentage.toFixed(1)}%</b> / {formatThresholdPercent(s()!.executeThreshold)}%
-                            </text>
-                            {/* Right: absolute token usage vs the model's
-                                full context window (separate from the
-                                execute threshold so users still know how
-                                much headroom remains beyond compaction). */}
-                            <text fg={contextSummaryColor()}>
-                                {compactTokens(s()!.inputTokens)} / {compactTokens(s()!.contextLimit)}
-                            </text>
-                        </box>
-                    )}
-                    <TokenBreakdown theme={props.theme} snapshot={s()!} />
-                </box>
-            )}
+            {/* Collapsed: compact bar + status line */}
+            <Show when={collapsed() && s() && s()!.inputTokens > 0}>
+                <TokenBreakdown theme={props.theme} snapshot={s()!} compact />
+                <text fg={props.theme.textMuted}>{collapsedStatusLineMemo()}</text>
+            </Show>
 
-            {/* Historian section */}
-            <box width="100%" marginTop={1} flexDirection="row" justifyContent="space-between">
-                <text fg={props.theme.text}>
-                    <b>Historian</b>
-                </text>
-                {s()?.historianRunning ? (
-                    <text fg={props.theme.warning}>compacting ⟳</text>
-                ) : (
-                    <text fg={props.theme.textMuted}>idle</text>
+            {/* Expanded: full sidebar content */}
+            <Show when={!collapsed()}>
+                {/* Token breakdown bar */}
+                {s() && s()!.inputTokens > 0 && (
+                    <box marginTop={1} flexDirection="column">
+                        {(s()?.contextLimit ?? 0) > 0 && (
+                            <box width="100%" flexDirection="row" justifyContent="space-between">
+                                {/* Left: current usage vs the per-model execute
+                                    threshold (the value Magic Context compares
+                                    against when scheduling historian / drops).
+                                    "47.5% / 65%" tells the user how close they
+                                    are to the next compaction trigger. */}
+                                <text fg={contextSummaryColor()}>
+                                    <b>{s()!.usagePercentage.toFixed(1)}%</b> / {formatThresholdPercent(s()!.executeThreshold)}%
+                                </text>
+                                {/* Right: absolute token usage vs the model's
+                                    full context window (separate from the
+                                    execute threshold so users still know how
+                                    much headroom remains beyond compaction). */}
+                                <text fg={contextSummaryColor()}>
+                                    {compactTokens(s()!.inputTokens)} / {compactTokens(s()!.contextLimit)}
+                                </text>
+                            </box>
+                        )}
+                        <TokenBreakdown theme={props.theme} snapshot={s()!} />
+                    </box>
                 )}
-            </box>
-            <StatRow
-                theme={props.theme}
-                label="Compartments"
-                value={String(s()?.compartmentCount ?? 0)}
-            />
-            <StatRow
-                theme={props.theme}
-                label="Facts"
-                value={String(s()?.factCount ?? 0)}
-            />
 
-            {/* Memory section */}
-            <SectionHeader theme={props.theme} title="Memory" />
-            <StatRow
-                theme={props.theme}
-                label="Memories"
-                value={String(s()?.memoryCount ?? 0)}
-                accent
-            />
-            {(s()?.memoryBlockCount ?? 0) > 0 && (
+                {/* Historian section */}
+                <box width="100%" marginTop={1} flexDirection="row" justifyContent="space-between">
+                    <text fg={props.theme.text}>
+                        <b>Historian</b>
+                    </text>
+                    {s()?.historianRunning ? (
+                        <text fg={props.theme.warning}>compacting ⟳</text>
+                    ) : (
+                        <text fg={props.theme.textMuted}>idle</text>
+                    )}
+                </box>
                 <StatRow
                     theme={props.theme}
-                    label="Injected"
-                    value={String(s()!.memoryBlockCount)}
-                    dim
+                    label="Compartments"
+                    value={String(s()?.compartmentCount ?? 0)}
                 />
-            )}
+                <StatRow
+                    theme={props.theme}
+                    label="Facts"
+                    value={String(s()?.factCount ?? 0)}
+                />
 
-            {/* Queue & Status */}
-            {((s()?.pendingOpsCount ?? 0) > 0 ||
-                (s()?.sessionNoteCount ?? 0) > 0 ||
-                (s()?.readySmartNoteCount ?? 0) > 0) && (
-                <>
-                    <SectionHeader theme={props.theme} title="Status" />
-                    {(s()?.pendingOpsCount ?? 0) > 0 && (
-                        <StatRow
-                            theme={props.theme}
-                            label="Queue"
-                            value={`${s()!.pendingOpsCount} pending`}
-                            warning
-                        />
-                    )}
-                    {(s()?.sessionNoteCount ?? 0) > 0 && (
-                        <StatRow
-                            theme={props.theme}
-                            label="Notes"
-                            value={String(s()!.sessionNoteCount)}
-                        />
-                    )}
-                    {(s()?.readySmartNoteCount ?? 0) > 0 && (
-                        <StatRow
-                            theme={props.theme}
-                            label="Smart Notes"
-                            value={`${s()!.readySmartNoteCount} ready`}
-                            accent
-                        />
-                    )}
-                </>
-            )}
-
-            {/* Dreamer */}
-            {s()?.lastDreamerRunAt && (
-                <>
-                    <SectionHeader theme={props.theme} title="Dreamer" />
+                {/* Memory section */}
+                <SectionHeader theme={props.theme} title="Memory" />
+                <StatRow
+                    theme={props.theme}
+                    label="Memories"
+                    value={String(s()?.memoryCount ?? 0)}
+                    accent
+                />
+                {(s()?.memoryBlockCount ?? 0) > 0 && (
                     <StatRow
                         theme={props.theme}
-                        label="Last run"
-                        value={relativeTime(s()!.lastDreamerRunAt!)}
+                        label="Injected"
+                        value={String(s()!.memoryBlockCount)}
                         dim
                     />
-                </>
-            )}
+                )}
 
-            {/* Stats — v0.21.8 ships a single "Total tokens" number while we
-                figure out how to present the new-work / reprocessed
-                categorization without confusing users. The underlying
-                snapshot fields (newWorkTokens, totalInputTokens) and the
-                session_meta columns are still populated; only the UI is
-                simplified for now. */}
-            {s()?.totalInputTokens != null && (
-                <>
-                    <SectionHeader theme={props.theme} title="Stats" />
-                    <StatRow
-                        theme={props.theme}
-                        label="Total tokens"
-                        value={compactTokens(s()!.totalInputTokens ?? 0)}
-                        dim
-                    />
-                </>
-            )}
+                {/* Queue & Status */}
+                {((s()?.pendingOpsCount ?? 0) > 0 ||
+                    (s()?.sessionNoteCount ?? 0) > 0 ||
+                    (s()?.readySmartNoteCount ?? 0) > 0) && (
+                    <>
+                        <SectionHeader theme={props.theme} title="Status" />
+                        {(s()?.pendingOpsCount ?? 0) > 0 && (
+                            <StatRow
+                                theme={props.theme}
+                                label="Queue"
+                                value={`${s()!.pendingOpsCount} pending`}
+                                warning
+                            />
+                        )}
+                        {(s()?.sessionNoteCount ?? 0) > 0 && (
+                            <StatRow
+                                theme={props.theme}
+                                label="Notes"
+                                value={String(s()!.sessionNoteCount)}
+                            />
+                        )}
+                        {(s()?.readySmartNoteCount ?? 0) > 0 && (
+                            <StatRow
+                                theme={props.theme}
+                                label="Smart Notes"
+                                value={`${s()!.readySmartNoteCount} ready`}
+                                accent
+                            />
+                        )}
+                    </>
+                )}
+
+                {/* Dreamer */}
+                {s()?.lastDreamerRunAt && (
+                    <>
+                        <SectionHeader theme={props.theme} title="Dreamer" />
+                        <StatRow
+                            theme={props.theme}
+                            label="Last run"
+                            value={relativeTime(s()!.lastDreamerRunAt!)}
+                            dim
+                        />
+                    </>
+                )}
+
+                {/* Stats — v0.21.8 ships a single "Total tokens" number while we
+                    figure out how to present the new-work / reprocessed
+                    categorization without confusing users. The underlying
+                    snapshot fields (newWorkTokens, totalInputTokens) and the
+                    session_meta columns are still populated; only the UI is
+                    simplified for now. */}
+                {s()?.totalInputTokens != null && (
+                    <>
+                        <SectionHeader theme={props.theme} title="Stats" />
+                        <StatRow
+                            theme={props.theme}
+                            label="Total tokens"
+                            value={compactTokens(s()!.totalInputTokens ?? 0)}
+                            dim
+                        />
+                    </>
+                )}
+            </Show>
         </box>
     )
 }

--- a/packages/plugin/src/tui/slots/sidebar-content.tsx
+++ b/packages/plugin/src/tui/slots/sidebar-content.tsx
@@ -3,7 +3,19 @@ import { createEffect, createMemo, createSignal, on, onCleanup, Show } from "sol
 import type { TuiSlotPlugin, TuiPluginApi, TuiThemeCurrent } from "@opencode-ai/plugin/tui"
 import packageJson from "../../../package.json"
 import { loadSidebarSnapshot, type SidebarSnapshot } from "../data/context-db"
-import { compactTokens, collapsedStatusLine, formatThresholdPercent, type CompactBarOptions, DEFAULT_COMPACT_BAR_OPTIONS } from "./sidebar-utils"
+import {
+    collapsedStatusLine,
+    collapsedUsagePercentSegment,
+    collapsedUsageTokensSegment,
+    compactTokens,
+    formatThresholdPercent,
+    parseTuiSidebarSettings,
+    persistSidebarCollapsed,
+    resolveInitialSidebarCollapsed,
+    type CompactBarOptions,
+    DEFAULT_COMPACT_BAR_OPTIONS,
+    type TuiSidebarSettings,
+} from "./sidebar-utils"
 import { readJsoncFile } from "../../shared/jsonc-parser"
 import { getOpenCodeConfigPaths } from "../../shared/opencode-config-dir"
 
@@ -189,7 +201,7 @@ const TokenBreakdown = (props: {
                 always fills the sidebar. In compact mode, wide-enough segments
                 show token-count labels centered over their colored box. */}
             <box width="100%" flexDirection="row" height={1}>
-                {(props.compact ? barSegments() : barSegments()).map((seg) => {
+                {barSegments().map((seg) => {
                     // Show label when segment is wide enough. Non-free segments
                     // show the short token count (3-4 chars e.g. "42K") at the
                     // labelThreshold. Free segments show just the number between
@@ -329,7 +341,7 @@ const SidebarContent = (props: {
     api: TuiPluginApi
     sessionID: () => string
     theme: TuiThemeCurrent
-    compactBarOptions?: CompactBarOptions
+    sidebarSettings: TuiSidebarSettings
 }) => {
     const [snapshot, setSnapshot] = createSignal<SidebarSnapshot | null>(null)
     let refreshTimer: ReturnType<typeof setTimeout> | undefined
@@ -403,15 +415,17 @@ const SidebarContent = (props: {
         return props.theme.accent
     })
 
-    // Collapse state persisted via KV (survives restarts)
-    const COLLAPSED_KV_KEY = "mc-sidebar-collapsed"
+    // Collapse state: config default until the user toggles, then KV wins.
     const [collapsed, setCollapsed] = createSignal(
-        props.api.kv.get(COLLAPSED_KV_KEY, false) as boolean,
+        resolveInitialSidebarCollapsed(props.api.kv, props.sidebarSettings.collapseDefault),
     )
-    createEffect(() => {
-        props.api.kv.set(COLLAPSED_KV_KEY, collapsed())
-    })
-    const toggle = () => setCollapsed((x) => !x)
+    const toggle = () => {
+        setCollapsed((prev) => {
+            const next = !prev
+            persistSidebarCollapsed(props.api.kv, next)
+            return next
+        })
+    }
 
     // Status line for collapsed view (line 3)
     const collapsedStatusLineMemo = createMemo(() => collapsedStatusLine(s()))
@@ -438,25 +452,32 @@ const SidebarContent = (props: {
                     <text fg={props.theme.textMuted}>v{packageJson.version}</text>
                 </box>
             }>
-                <Show when={s() && s()!.inputTokens > 0 && (s()?.contextLimit ?? 0) > 0} fallback={
+                <Show when={s() && (s()?.contextLimit ?? 0) > 0} fallback={
                     <box flexDirection="row" onMouseDown={toggle}>
                         <text fg={props.theme.textMuted}>▶ Magic Context</text>
                     </box>
                 }>
                     <box flexDirection="row" width="100%" justifyContent="space-between" onMouseDown={toggle}>
                         <text fg={contextSummaryColor()}>
-                            <b>▶</b> {s()!.usagePercentage.toFixed(1)}% / {formatThresholdPercent(s()!.executeThreshold)}%
+                            <b>▶</b> {collapsedUsagePercentSegment(s()!.usagePercentage, s()!.executeThreshold)}
                         </text>
                         <text fg={contextSummaryColor()}>
-                            {compactTokens(s()!.inputTokens)} / {compactTokens(s()!.contextLimit)}
+                            {collapsedUsageTokensSegment(s()!.inputTokens, s()!.contextLimit)}
                         </text>
                     </box>
                 </Show>
             </Show>
 
-            {/* Collapsed: compact bar + status line */}
-            <Show when={collapsed() && s() && s()!.inputTokens > 0}>
-                <TokenBreakdown theme={props.theme} snapshot={s()!} compact compactBarOptions={props.compactBarOptions} />
+            {/* Collapsed: compact bar (when usage exists) + status line (always when snapshot loaded) */}
+            <Show when={collapsed() && s()}>
+                <Show when={s()!.inputTokens > 0}>
+                    <TokenBreakdown
+                        theme={props.theme}
+                        snapshot={s()!}
+                        compact
+                        compactBarOptions={props.sidebarSettings.compactBarOptions}
+                    />
+                </Show>
                 <text fg={props.theme.textMuted}>{collapsedStatusLineMemo()}</text>
             </Show>
 
@@ -594,27 +615,18 @@ const SidebarContent = (props: {
     )
 }
 
+function loadTuiSidebarSettings(): TuiSidebarSettings {
+    try {
+        const cfgPaths = getOpenCodeConfigPaths({ binary: "opencode" })
+        const cfg = readJsoncFile<Record<string, unknown>>(cfgPaths.omoConfig)
+        return parseTuiSidebarSettings(cfg)
+    } catch {
+        return { collapseDefault: false }
+    }
+}
+
 export function createSidebarContentSlot(api: TuiPluginApi): TuiSlotPlugin {
-    // Read compact_bar config from magic-context.jsonc (silently falls back to defaults)
-    const compactBarOptions = (() => {
-        try {
-            const cfgPaths = getOpenCodeConfigPaths({ binary: "opencode" })
-            const cfg = readJsoncFile<Record<string, unknown>>(cfgPaths.omoConfig)
-            if (!cfg || typeof cfg !== "object") return undefined
-            const tuiSection = (cfg as Record<string, unknown>).tui
-            if (!tuiSection || typeof tuiSection !== "object") return undefined
-            const compactBar = (tuiSection as Record<string, unknown>).compact_bar
-            if (!compactBar || typeof compactBar !== "object") return undefined
-            const cb = compactBar as Record<string, unknown>
-            const opts: CompactBarOptions = {}
-            if (typeof cb.label_threshold === "number") opts.labelThreshold = cb.label_threshold
-            if (typeof cb.free_label_threshold === "number") opts.freeLabelThreshold = cb.free_label_threshold
-            if (typeof cb.show_free_label === "boolean") opts.showFreeLabel = cb.show_free_label
-            return Object.keys(opts).length > 0 ? opts : undefined
-        } catch {
-            return undefined
-        }
-    })()
+    const sidebarSettings = loadTuiSidebarSettings()
     return {
         order: 150,
         slots: {
@@ -625,7 +637,7 @@ export function createSidebarContentSlot(api: TuiPluginApi): TuiSlotPlugin {
                         api={api}
                         sessionID={() => value.session_id}
                         theme={theme()}
-                        compactBarOptions={compactBarOptions}
+                        sidebarSettings={sidebarSettings}
                     />
                 )
             },

--- a/packages/plugin/src/tui/slots/sidebar-content.tsx
+++ b/packages/plugin/src/tui/slots/sidebar-content.tsx
@@ -3,7 +3,9 @@ import { createEffect, createMemo, createSignal, on, onCleanup, Show } from "sol
 import type { TuiSlotPlugin, TuiPluginApi, TuiThemeCurrent } from "@opencode-ai/plugin/tui"
 import packageJson from "../../../package.json"
 import { loadSidebarSnapshot, type SidebarSnapshot } from "../data/context-db"
-import { compactTokens, collapsedStatusLine, formatThresholdPercent } from "./sidebar-utils"
+import { compactTokens, collapsedStatusLine, formatThresholdPercent, type CompactBarOptions, DEFAULT_COMPACT_BAR_OPTIONS } from "./sidebar-utils"
+import { readJsoncFile } from "../../shared/jsonc-parser"
+import { getOpenCodeConfigPaths } from "../../shared/opencode-config-dir"
 
 const SINGLE_BORDER = { type: "single" } as any
 const REFRESH_DEBOUNCE_MS = 150
@@ -45,7 +47,12 @@ const TokenBreakdown = (props: {
     theme: TuiThemeCurrent
     snapshot: SidebarSnapshot
     compact?: boolean
+    compactBarOptions?: CompactBarOptions
 }) => {
+    const barOpts = createMemo(() => ({
+        ...DEFAULT_COMPACT_BAR_OPTIONS,
+        ...props.compactBarOptions,
+    }))
     // The bar is rendered as a flex row of colored boxes, each with
     // flexGrow=tokens and flexBasis=0. opentui distributes the parent
     // container's full width proportionally, so the bar always fills the
@@ -183,12 +190,16 @@ const TokenBreakdown = (props: {
                 show token-count labels centered over their colored box. */}
             <box width="100%" flexDirection="row" height={1}>
                 {(props.compact ? barSegments() : barSegments()).map((seg) => {
-                    // In compact mode, overlay a label when the segment is
-                    // wide enough (≥8% of the total). Free segments get the
-                    // "XXK Free" label at ≥12% to accommodate the longer text.
+                    // Show label when segment is wide enough. Non-free segments
+                    // show the short token count (3-4 chars e.g. "42K") at the
+                    // labelThreshold. Free segments show just the number between
+                    // labelThreshold and freeLabelThreshold, and the full
+                    // "XXK Free" label at freeLabelThreshold+.
                     const pct = seg.tokens / totalTokens()
-                    const showLabel = props.compact && pct >= 0.08 && seg.key !== "free"
-                    const showFreeLabel = props.compact && seg.key === "free" && pct >= 0.12
+                    const { labelThreshold, freeLabelThreshold } = barOpts()
+                    const showLabel = props.compact && pct >= labelThreshold && seg.key !== "free"
+                    const showFreeLabel = props.compact && seg.key === "free" && barOpts().showFreeLabel && pct >= freeLabelThreshold
+                    const showFreeShort = props.compact && seg.key === "free" && pct >= labelThreshold && (!barOpts().showFreeLabel || pct < freeLabelThreshold)
 
                     if (showFreeLabel) {
                         return (
@@ -201,8 +212,27 @@ const TokenBreakdown = (props: {
                                 flexDirection="row"
                                 alignItems="center"
                                 justifyContent="center"
+                                overflow="hidden"
                             >
                                 <text fg={props.theme.background}>{`${compactTokens(seg.tokens)} Free`}</text>
+                            </box>
+                        )
+                    }
+
+                    if (showFreeShort) {
+                        return (
+                            <box
+                                key={seg.key}
+                                flexGrow={Math.max(1, seg.tokens)}
+                                flexBasis={0}
+                                height={1}
+                                backgroundColor={seg.color}
+                                flexDirection="row"
+                                alignItems="center"
+                                justifyContent="center"
+                                overflow="hidden"
+                            >
+                                <text fg={props.theme.background}>{compactTokens(seg.tokens)}</text>
                             </box>
                         )
                     }
@@ -218,6 +248,7 @@ const TokenBreakdown = (props: {
                                 flexDirection="row"
                                 alignItems="center"
                                 justifyContent="center"
+                                overflow="hidden"
                             >
                                 <text fg={props.theme.background}>{compactTokens(seg.tokens)}</text>
                             </box>
@@ -298,6 +329,7 @@ const SidebarContent = (props: {
     api: TuiPluginApi
     sessionID: () => string
     theme: TuiThemeCurrent
+    compactBarOptions?: CompactBarOptions
 }) => {
     const [snapshot, setSnapshot] = createSignal<SidebarSnapshot | null>(null)
     let refreshTimer: ReturnType<typeof setTimeout> | undefined
@@ -424,7 +456,7 @@ const SidebarContent = (props: {
 
             {/* Collapsed: compact bar + status line */}
             <Show when={collapsed() && s() && s()!.inputTokens > 0}>
-                <TokenBreakdown theme={props.theme} snapshot={s()!} compact />
+                <TokenBreakdown theme={props.theme} snapshot={s()!} compact compactBarOptions={props.compactBarOptions} />
                 <text fg={props.theme.textMuted}>{collapsedStatusLineMemo()}</text>
             </Show>
 
@@ -563,6 +595,26 @@ const SidebarContent = (props: {
 }
 
 export function createSidebarContentSlot(api: TuiPluginApi): TuiSlotPlugin {
+    // Read compact_bar config from magic-context.jsonc (silently falls back to defaults)
+    const compactBarOptions = (() => {
+        try {
+            const cfgPaths = getOpenCodeConfigPaths({ binary: "opencode" })
+            const cfg = readJsoncFile<Record<string, unknown>>(cfgPaths.omoConfig)
+            if (!cfg || typeof cfg !== "object") return undefined
+            const tuiSection = (cfg as Record<string, unknown>).tui
+            if (!tuiSection || typeof tuiSection !== "object") return undefined
+            const compactBar = (tuiSection as Record<string, unknown>).compact_bar
+            if (!compactBar || typeof compactBar !== "object") return undefined
+            const cb = compactBar as Record<string, unknown>
+            const opts: CompactBarOptions = {}
+            if (typeof cb.label_threshold === "number") opts.labelThreshold = cb.label_threshold
+            if (typeof cb.free_label_threshold === "number") opts.freeLabelThreshold = cb.free_label_threshold
+            if (typeof cb.show_free_label === "boolean") opts.showFreeLabel = cb.show_free_label
+            return Object.keys(opts).length > 0 ? opts : undefined
+        } catch {
+            return undefined
+        }
+    })()
     return {
         order: 150,
         slots: {
@@ -573,6 +625,7 @@ export function createSidebarContentSlot(api: TuiPluginApi): TuiSlotPlugin {
                         api={api}
                         sessionID={() => value.session_id}
                         theme={theme()}
+                        compactBarOptions={compactBarOptions}
                     />
                 )
             },

--- a/packages/plugin/src/tui/slots/sidebar-utils.test.ts
+++ b/packages/plugin/src/tui/slots/sidebar-utils.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "bun:test"
+import { compactTokens, collapsedStatusLine, collapsedUsageLine } from "./sidebar-utils"
+import type { SidebarSnapshot } from "../../shared/rpc-types"
+
+// ---------------------------------------------------------------------------
+// compactTokens
+// ---------------------------------------------------------------------------
+describe("compactTokens", () => {
+    it("returns the number as-is below 1000", () => {
+        expect(compactTokens(0)).toBe("0")
+        expect(compactTokens(1)).toBe("1")
+        expect(compactTokens(500)).toBe("500")
+        expect(compactTokens(999)).toBe("999")
+    })
+
+    it("formats thousands with K suffix (no decimal)", () => {
+        expect(compactTokens(1_000)).toBe("1K")
+        expect(compactTokens(10_000)).toBe("10K")
+        expect(compactTokens(999_999)).toBe("1000K") // 999999/1000 = 999.999 → "1000K"
+    })
+
+    it("formats millions with M suffix (one decimal)", () => {
+        expect(compactTokens(1_000_000)).toBe("1.0M")
+        expect(compactTokens(1_200_000)).toBe("1.2M")
+        expect(compactTokens(100_000_000)).toBe("100.0M")
+    })
+
+    it("handles very small values correctly", () => {
+        // Below 1000 — no suffix
+        expect(compactTokens(0)).toBe("0")
+        expect(compactTokens(1)).toBe("1")
+        expect(compactTokens(99)).toBe("99")
+    })
+
+    it("handles boundary between K and M", () => {
+        // Exactly at the threshold
+        expect(compactTokens(999_999)).toBe("1000K") // rounds up
+        expect(compactTokens(1_000_000)).toBe("1.0M")
+    })
+})
+
+// ---------------------------------------------------------------------------
+// collapsedStatusLine
+// ---------------------------------------------------------------------------
+describe("collapsedStatusLine", () => {
+    const baseSnapshot = (overrides: Partial<SidebarSnapshot> = {}): SidebarSnapshot => ({
+        usagePercentage: 0,
+        inputTokens: 0,
+        limitTokens: 0,
+        executeThreshold: 65,
+        contextLimit: 200_000,
+        systemPromptTokens: 0,
+        compartmentTokens: 0,
+        factTokens: 0,
+        memoryTokens: 0,
+        conversationTokens: 0,
+        toolCallTokens: 0,
+        toolDefinitionTokens: 0,
+        historianRunning: false,
+        compartmentInProgress: false,
+        lastDreamerRunAt: null,
+        pendingOpsCount: 0,
+        compartmentCount: 3,
+        factCount: 5,
+        memoryCount: 5,
+        memoryBlockCount: 0,
+        sessionNoteCount: 0,
+        readySmartNoteCount: 0,
+        ...overrides,
+    })
+
+    it("returns empty string for null snapshot", () => {
+        expect(collapsedStatusLine(null)).toBe("")
+    })
+
+    it("reports historian compacting when historianRunning is true", () => {
+        const result = collapsedStatusLine(baseSnapshot({ historianRunning: true }))
+        expect(result).toContain("compacting")
+        expect(result).toContain("⟳")
+    })
+
+    it("reports historian compacting when compartmentInProgress is true", () => {
+        const result = collapsedStatusLine(baseSnapshot({ compartmentInProgress: true }))
+        expect(result).toContain("compacting")
+        expect(result).toContain("⟳")
+    })
+
+    it("prefers historian/compaction over dreamer", () => {
+        // Both active — historian wins
+        const result = collapsedStatusLine(
+            baseSnapshot({
+                historianRunning: true,
+                lastDreamerRunAt: Date.now() - 10_000,
+            }),
+        )
+        expect(result).toContain("compacting")
+    })
+
+    it("reports dreamer active when recently run", () => {
+        const result = collapsedStatusLine(
+            baseSnapshot({ lastDreamerRunAt: Date.now() - 30_000 }),
+        )
+        expect(result).toContain("Dreamer")
+        expect(result).toContain("⟳")
+    })
+
+    it("reports pending queue when ops are waiting", () => {
+        const result = collapsedStatusLine(baseSnapshot({ pendingOpsCount: 3 }))
+        expect(result).toContain("Queue")
+        expect(result).toContain("3 pending")
+    })
+
+    it("shows static counts when nothing is active", () => {
+        const result = collapsedStatusLine(baseSnapshot())
+        expect(result).toBe("3 Comp · 5 Fact · 5 Memory")
+    })
+
+    it("shows zero counts correctly", () => {
+        const result = collapsedStatusLine(
+            baseSnapshot({
+                historianRunning: false,
+                lastDreamerRunAt: null,
+                pendingOpsCount: 0,
+                compartmentCount: 0,
+                factCount: 0,
+                memoryCount: 0,
+            }),
+        )
+        expect(result).toBe("0 Comp · 0 Fact · 0 Memory")
+    })
+})
+
+// ---------------------------------------------------------------------------
+// collapsedUsageLine
+// ---------------------------------------------------------------------------
+describe("collapsedUsageLine", () => {
+    it("renders integer threshold without decimals", () => {
+        const line = collapsedUsageLine(47.5, 65, 111_000, 180_000)
+        expect(line).toBe("47.5% / 65%  111K / 180K")
+    })
+
+    it("renders fractional threshold with one decimal", () => {
+        const line = collapsedUsageLine(47.5, 14.099, 111_000, 180_000)
+        expect(line).toBe("47.5% / 14%  111K / 180K")
+    })
+
+    it("shows em-dash for missing threshold", () => {
+        const line = collapsedUsageLine(10, null, 1000, 2000)
+        expect(line).toBe("10.0% / —%  1K / 2K")
+    })
+
+    it("shows em-dash for missing context limit", () => {
+        const line = collapsedUsageLine(10, 65, 1000, 0)
+        expect(line).toBe("10.0% / 65%  1K / —")
+    })
+
+    it("shows em-dash when both threshold and limit are missing", () => {
+        const line = collapsedUsageLine(0, undefined, 0, null)
+        expect(line).toBe("0.0% / —%  0 / —")
+    })
+
+    it("handles small token counts without suffix", () => {
+        const line = collapsedUsageLine(0.5, 65, 500, 2000)
+        expect(line).toBe("0.5% / 65%  500 / 2K")
+    })
+
+    it("accepts a custom compactTokens function", () => {
+        const customCompact = (v: number) => `[${v}]`
+        const line = collapsedUsageLine(50, 65, 1000, 2000, customCompact)
+        expect(line).toBe("50.0% / 65%  [1000] / [2000]")
+    })
+})

--- a/packages/plugin/src/tui/slots/sidebar-utils.test.ts
+++ b/packages/plugin/src/tui/slots/sidebar-utils.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from "bun:test"
-import { compactTokens, collapsedStatusLine, collapsedUsageLine } from "./sidebar-utils"
+import {
+    COLLAPSED_KV_KEY,
+    COLLAPSED_USER_SET_KV_KEY,
+    compactTokens,
+    collapsedStatusLine,
+    collapsedUsageLine,
+    collapsedUsagePercentSegment,
+    collapsedUsageTokensSegment,
+    parseTuiSidebarSettings,
+    persistSidebarCollapsed,
+    resolveInitialSidebarCollapsed,
+} from "./sidebar-utils"
 import type { SidebarSnapshot } from "../../shared/rpc-types"
 
 // ---------------------------------------------------------------------------
@@ -16,7 +27,7 @@ describe("compactTokens", () => {
     it("formats thousands with K suffix (no decimal)", () => {
         expect(compactTokens(1_000)).toBe("1K")
         expect(compactTokens(10_000)).toBe("10K")
-        expect(compactTokens(999_999)).toBe("1000K") // 999999/1000 = 999.999 → "1000K"
+        expect(compactTokens(999_999)).toBe("999K")
     })
 
     it("formats millions with M suffix (one decimal)", () => {
@@ -26,16 +37,99 @@ describe("compactTokens", () => {
     })
 
     it("handles very small values correctly", () => {
-        // Below 1000 — no suffix
         expect(compactTokens(0)).toBe("0")
         expect(compactTokens(1)).toBe("1")
         expect(compactTokens(99)).toBe("99")
     })
 
     it("handles boundary between K and M", () => {
-        // Exactly at the threshold
-        expect(compactTokens(999_999)).toBe("1000K") // rounds up
+        expect(compactTokens(999_999)).toBe("999K")
         expect(compactTokens(1_000_000)).toBe("1.0M")
+    })
+})
+
+// ---------------------------------------------------------------------------
+// parseTuiSidebarSettings
+// ---------------------------------------------------------------------------
+describe("parseTuiSidebarSettings", () => {
+    it("returns defaults for missing config", () => {
+        expect(parseTuiSidebarSettings(null)).toEqual({ collapseDefault: false })
+        expect(parseTuiSidebarSettings({})).toEqual({ collapseDefault: false })
+    })
+
+    it("reads collapse_default from tui.sidebar", () => {
+        expect(
+            parseTuiSidebarSettings({
+                tui: { sidebar: { collapse_default: true } },
+            }),
+        ).toEqual({ collapseDefault: true })
+    })
+
+    it("reads and clamps compact_bar thresholds", () => {
+        expect(
+            parseTuiSidebarSettings({
+                tui: {
+                    compact_bar: {
+                        label_threshold: 0.99,
+                        free_label_threshold: 0.01,
+                        show_free_label: false,
+                    },
+                },
+            }),
+        ).toEqual({
+            collapseDefault: false,
+            compactBarOptions: {
+                labelThreshold: 0.5,
+                freeLabelThreshold: 0.1,
+                showFreeLabel: false,
+            },
+        })
+    })
+})
+
+// ---------------------------------------------------------------------------
+// resolveInitialSidebarCollapsed
+// ---------------------------------------------------------------------------
+describe("resolveInitialSidebarCollapsed", () => {
+    it("uses collapse_default when user has not toggled", () => {
+        const kv = new Map<string, unknown>()
+        const api = {
+            get: (key: string, def: unknown) => kv.get(key) ?? def,
+            set: (key: string, val: unknown) => {
+                kv.set(key, val)
+            },
+        }
+        expect(resolveInitialSidebarCollapsed(api, true)).toBe(true)
+        expect(resolveInitialSidebarCollapsed(api, false)).toBe(false)
+        expect(kv.has(COLLAPSED_KV_KEY)).toBe(false)
+    })
+
+    it("uses KV when user has toggled", () => {
+        const kv = new Map<string, unknown>([
+            [COLLAPSED_USER_SET_KV_KEY, true],
+            [COLLAPSED_KV_KEY, false],
+        ])
+        const api = {
+            get: (key: string, def: unknown) => kv.get(key) ?? def,
+            set: (key: string, val: unknown) => {
+                kv.set(key, val)
+            },
+        }
+        expect(resolveInitialSidebarCollapsed(api, true)).toBe(false)
+    })
+
+    it("persistSidebarCollapsed marks user-set and stores value", () => {
+        const kv = new Map<string, unknown>()
+        const api = {
+            get: (key: string, def: unknown) => kv.get(key) ?? def,
+            set: (key: string, val: unknown) => {
+                kv.set(key, val)
+            },
+        }
+        persistSidebarCollapsed(api, true)
+        expect(kv.get(COLLAPSED_KV_KEY)).toBe(true)
+        expect(kv.get(COLLAPSED_USER_SET_KV_KEY)).toBe(true)
+        expect(resolveInitialSidebarCollapsed(api, false)).toBe(true)
     })
 })
 
@@ -86,7 +180,6 @@ describe("collapsedStatusLine", () => {
     })
 
     it("prefers historian/compaction over dreamer", () => {
-        // Both active — historian wins
         const result = collapsedStatusLine(
             baseSnapshot({
                 historianRunning: true,
@@ -108,6 +201,13 @@ describe("collapsedStatusLine", () => {
         const result = collapsedStatusLine(baseSnapshot({ pendingOpsCount: 3 }))
         expect(result).toContain("Queue")
         expect(result).toContain("3 pending")
+    })
+
+    it("reports session notes when idle but notes exist", () => {
+        const result = collapsedStatusLine(
+            baseSnapshot({ sessionNoteCount: 2, readySmartNoteCount: 1 }),
+        )
+        expect(result).toBe("2 Notes · 1 Smart")
     })
 
     it("shows static counts when nothing is active", () => {
@@ -139,9 +239,9 @@ describe("collapsedUsageLine", () => {
         expect(line).toBe("47.5% / 65%  111K / 180K")
     })
 
-    it("renders fractional threshold with one decimal", () => {
+    it("renders fractional threshold with one decimal via formatThresholdPercent", () => {
         const line = collapsedUsageLine(47.5, 14.099, 111_000, 180_000)
-        expect(line).toBe("47.5% / 14%  111K / 180K")
+        expect(line).toBe("47.5% / 14.1%  111K / 180K")
     })
 
     it("shows em-dash for missing threshold", () => {
@@ -168,5 +268,17 @@ describe("collapsedUsageLine", () => {
         const customCompact = (v: number) => `[${v}]`
         const line = collapsedUsageLine(50, 65, 1000, 2000, customCompact)
         expect(line).toBe("50.0% / 65%  [1000] / [2000]")
+    })
+})
+
+describe("collapsedUsagePercentSegment", () => {
+    it("matches formatThresholdPercent for fractional thresholds", () => {
+        expect(collapsedUsagePercentSegment(47.5, 14.099)).toBe("47.5% / 14.1%")
+    })
+})
+
+describe("collapsedUsageTokensSegment", () => {
+    it("formats token pair", () => {
+        expect(collapsedUsageTokensSegment(111_000, 180_000)).toBe("111K / 180K")
     })
 })

--- a/packages/plugin/src/tui/slots/sidebar-utils.ts
+++ b/packages/plugin/src/tui/slots/sidebar-utils.ts
@@ -1,0 +1,56 @@
+import type { SidebarSnapshot } from "../../shared/rpc-types"
+
+/**
+ * Compact byte/token count to a human-readable string.
+ * Examples: 999 → "999", 1000 → "1K", 15300 → "15K", 1_200_000 → "1.2M"
+ */
+export function compactTokens(value: number): string {
+    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+    if (value >= 1_000) return `${(value / 1_000).toFixed(0)}K`
+    return String(value)
+}
+
+/**
+ * Build a one-line status summary for the collapsed sidebar view.
+ * Prioritises active operations (historian, dreamer, pending queue)
+ * over static counts.
+ */
+export function collapsedStatusLine(snap: SidebarSnapshot | null): string {
+    if (!snap) return ""
+    if (snap.historianRunning || snap.compartmentInProgress) {
+        return "Historian compacting ⟳"
+    }
+    if (snap.lastDreamerRunAt && Date.now() - snap.lastDreamerRunAt < 60_000) {
+        return "Dreamer active ⟳"
+    }
+    if (snap.pendingOpsCount > 0) {
+        return `Queue: ${snap.pendingOpsCount} pending`
+    }
+    return `${snap.compartmentCount} Comp · ${snap.factCount} Fact · ${snap.memoryCount} Memory`
+}
+
+/**
+ * Summary usage string for the collapsed header line.
+ * Returns something like "47.5% / 65%  111K / 180K"
+ */
+export function collapsedUsageLine(
+    usagePercentage: number,
+    executeThreshold: number | undefined | null,
+    inputTokens: number,
+    contextLimit: number | undefined | null,
+    compactTokensFn: (v: number) => string = compactTokens,
+): string {
+    const pct = usagePercentage.toFixed(1)
+    const thresh =
+        typeof executeThreshold === "number" && Number.isFinite(executeThreshold)
+            ? Math.round(executeThreshold).toString()
+            : "—"
+    const used = compactTokensFn(inputTokens)
+    const limit =
+        typeof contextLimit === "number" && contextLimit > 0
+            ? compactTokensFn(contextLimit)
+            : "—"
+    return `${pct}% / ${thresh}%  ${used} / ${limit}`
+}
+
+export { formatThresholdPercent } from "../../shared/format-threshold"

--- a/packages/plugin/src/tui/slots/sidebar-utils.ts
+++ b/packages/plugin/src/tui/slots/sidebar-utils.ts
@@ -1,5 +1,31 @@
 import type { SidebarSnapshot } from "../../shared/rpc-types"
 
+// ---------------------------------------------------------------------------
+// Compact bar configuration (from magic-context.jsonc → compact_bar)
+// ---------------------------------------------------------------------------
+
+/** User-configurable options for the collapsed sidebar token usage bar. */
+export interface CompactBarOptions {
+    /** Minimum segment share (0-1) to show the short token-count label on
+     * non-Free segments. Higher values reduce label clutter on narrow bars.
+     * Default: 0.10 */
+    labelThreshold?: number
+    /** Minimum segment share (0-1) to show the full "XXK Free" label on the
+     * last (free-context) segment. Below this threshold only the number is
+     * shown. Default: 0.25 */
+    freeLabelThreshold?: number
+    /** Whether to append " Free" to the last segment's label. When false,
+     * only the token count is shown regardless of segment width.
+     * Default: true */
+    showFreeLabel?: boolean
+}
+
+export const DEFAULT_COMPACT_BAR_OPTIONS: Required<CompactBarOptions> = {
+    labelThreshold: 0.10,
+    freeLabelThreshold: 0.25,
+    showFreeLabel: true,
+}
+
 /**
  * Compact byte/token count to a human-readable string.
  * Examples: 999 → "999", 1000 → "1K", 15300 → "15K", 1_200_000 → "1.2M"

--- a/packages/plugin/src/tui/slots/sidebar-utils.ts
+++ b/packages/plugin/src/tui/slots/sidebar-utils.ts
@@ -1,4 +1,5 @@
 import type { SidebarSnapshot } from "../../shared/rpc-types"
+import { formatThresholdPercent } from "../../shared/format-threshold"
 
 // ---------------------------------------------------------------------------
 // Compact bar configuration (from magic-context.jsonc → compact_bar)
@@ -26,19 +27,92 @@ export const DEFAULT_COMPACT_BAR_OPTIONS: Required<CompactBarOptions> = {
     showFreeLabel: true,
 }
 
+export interface TuiSidebarSettings {
+    collapseDefault: boolean
+    compactBarOptions?: CompactBarOptions
+}
+
+export const COLLAPSED_KV_KEY = "mc-sidebar-collapsed"
+export const COLLAPSED_USER_SET_KV_KEY = "mc-sidebar-collapsed-user-set"
+
+type SidebarKv = {
+    get: (key: string, defaultValue: unknown) => unknown
+    set: (key: string, value: unknown) => void
+}
+
+function clampThreshold(value: number, min: number, max: number): number {
+    if (!Number.isFinite(value)) return min
+    return Math.min(max, Math.max(min, value))
+}
+
+/** Parse `tui` section from magic-context.jsonc (pure — no file I/O). */
+export function parseTuiSidebarSettings(cfg: Record<string, unknown> | null | undefined): TuiSidebarSettings {
+    const result: TuiSidebarSettings = { collapseDefault: false }
+    if (!cfg || typeof cfg !== "object") return result
+
+    const tuiSection = cfg.tui
+    if (!tuiSection || typeof tuiSection !== "object") return result
+
+    const tui = tuiSection as Record<string, unknown>
+
+    const sidebar = tui.sidebar
+    if (sidebar && typeof sidebar === "object") {
+        const collapseDefault = (sidebar as Record<string, unknown>).collapse_default
+        if (typeof collapseDefault === "boolean") {
+            result.collapseDefault = collapseDefault
+        }
+    }
+
+    const compactBar = tui.compact_bar
+    if (compactBar && typeof compactBar === "object") {
+        const cb = compactBar as Record<string, unknown>
+        const opts: CompactBarOptions = {}
+        if (typeof cb.label_threshold === "number") {
+            opts.labelThreshold = clampThreshold(cb.label_threshold, 0.05, 0.5)
+        }
+        if (typeof cb.free_label_threshold === "number") {
+            opts.freeLabelThreshold = clampThreshold(cb.free_label_threshold, 0.1, 0.5)
+        }
+        if (typeof cb.show_free_label === "boolean") {
+            opts.showFreeLabel = cb.show_free_label
+        }
+        if (Object.keys(opts).length > 0) {
+            result.compactBarOptions = opts
+        }
+    }
+
+    return result
+}
+
+/** Initial collapse: KV after explicit user toggle, else `collapse_default` from config. */
+export function resolveInitialSidebarCollapsed(
+    kv: SidebarKv,
+    collapseDefault: boolean,
+): boolean {
+    if (kv.get(COLLAPSED_USER_SET_KV_KEY, false) === true) {
+        return kv.get(COLLAPSED_KV_KEY, false) === true
+    }
+    return collapseDefault
+}
+
+export function persistSidebarCollapsed(kv: SidebarKv, collapsed: boolean): void {
+    kv.set(COLLAPSED_KV_KEY, collapsed)
+    kv.set(COLLAPSED_USER_SET_KV_KEY, true)
+}
+
 /**
  * Compact byte/token count to a human-readable string.
  * Examples: 999 → "999", 1000 → "1K", 15300 → "15K", 1_200_000 → "1.2M"
  */
 export function compactTokens(value: number): string {
     if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
-    if (value >= 1_000) return `${(value / 1_000).toFixed(0)}K`
+    if (value >= 1_000) return `${Math.floor(value / 1_000)}K`
     return String(value)
 }
 
 /**
  * Build a one-line status summary for the collapsed sidebar view.
- * Prioritises active operations (historian, dreamer, pending queue)
+ * Prioritises active operations (historian, dreamer, pending queue, notes)
  * over static counts.
  */
 export function collapsedStatusLine(snap: SidebarSnapshot | null): string {
@@ -52,12 +126,44 @@ export function collapsedStatusLine(snap: SidebarSnapshot | null): string {
     if (snap.pendingOpsCount > 0) {
         return `Queue: ${snap.pendingOpsCount} pending`
     }
+    const noteParts: string[] = []
+    if (snap.sessionNoteCount > 0) {
+        noteParts.push(`${snap.sessionNoteCount} Notes`)
+    }
+    if (snap.readySmartNoteCount > 0) {
+        noteParts.push(`${snap.readySmartNoteCount} Smart`)
+    }
+    if (noteParts.length > 0) {
+        return noteParts.join(" · ")
+    }
     return `${snap.compartmentCount} Comp · ${snap.factCount} Fact · ${snap.memoryCount} Memory`
+}
+
+/** Left segment of the collapsed usage header, e.g. `47.5% / 65%`. */
+export function collapsedUsagePercentSegment(
+    usagePercentage: number,
+    executeThreshold: number | undefined | null,
+): string {
+    return `${usagePercentage.toFixed(1)}% / ${formatThresholdPercent(executeThreshold)}%`
+}
+
+/** Right segment of the collapsed usage header, e.g. `111K / 180K`. */
+export function collapsedUsageTokensSegment(
+    inputTokens: number,
+    contextLimit: number | undefined | null,
+    compactTokensFn: (v: number) => string = compactTokens,
+): string {
+    const used = compactTokensFn(inputTokens)
+    const limit =
+        typeof contextLimit === "number" && contextLimit > 0
+            ? compactTokensFn(contextLimit)
+            : "—"
+    return `${used} / ${limit}`
 }
 
 /**
  * Summary usage string for the collapsed header line.
- * Returns something like "47.5% / 65%  111K / 180K"
+ * Returns something like `47.5% / 65%  111K / 180K`
  */
 export function collapsedUsageLine(
     usagePercentage: number,
@@ -66,17 +172,9 @@ export function collapsedUsageLine(
     contextLimit: number | undefined | null,
     compactTokensFn: (v: number) => string = compactTokens,
 ): string {
-    const pct = usagePercentage.toFixed(1)
-    const thresh =
-        typeof executeThreshold === "number" && Number.isFinite(executeThreshold)
-            ? Math.round(executeThreshold).toString()
-            : "—"
-    const used = compactTokensFn(inputTokens)
-    const limit =
-        typeof contextLimit === "number" && contextLimit > 0
-            ? compactTokensFn(contextLimit)
-            : "—"
-    return `${pct}% / ${thresh}%  ${used} / ${limit}`
+    const left = collapsedUsagePercentSegment(usagePercentage, executeThreshold)
+    const right = collapsedUsageTokensSegment(inputTokens, contextLimit, compactTokensFn)
+    return `${left}  ${right}`
 }
 
 export { formatThresholdPercent } from "../../shared/format-threshold"


### PR DESCRIPTION
## Summary

The Magic Context sidebar in OpenCode's TUI can now be collapsed into a compact 3-line view by clicking the header. This frees up sidebar space while keeping the most essential context information visible at a glance.

<img width="538" height="117" alt="image" src="https://github.com/user-attachments/assets/2334717c-ed1f-4ab6-9df2-3afc009bcc12" />

<img width="570" height="117" alt="image" src="https://github.com/user-attachments/assets/c7b07dd3-87af-4cad-8430-9819d6da25ea" />



**Suggestion 1** (I didn't implement this, but it could be a good idea): consider sorting the context categories by their size in context window. Currently the categories are displayed in static order (System ->Compartments ->Memories -> Conversation ->Tool Calls ->Tool Defs), which is also okay when you don't want to see categories jumping up and down because of re-sorting. But having an option to see a list of 'heaviest' categories taking space in context window would be preferable to some people.
**Suggestion 2**: Is there a separate category for 'Skills Defs', or are they bundled together with 'Tool Defs'? Skill definitions can bloat the context window as much as tool/MCP definitions, when you have too many packed in the .agents/ folders.

## What changed

- **Collapse via header click** — clicking the Magic Context header toggles between the full expanded sidebar and a compact summary. The collapsed header shows real-time context usage (percentage and absolute tokens) instead of the brand title.
- **State persisted across restarts** — collapsed/expanded state is stored in `api.kv`, so it survives session restarts and window reloads.
- **Compact color-coded token bar** — the segmented usage bar shrinks to a single row with proportional `flexGrow`-based segments, filling the full sidebar width. Includes a "Free" segment (dim gray `░`) for unused context, with token-count labels overlaid on wide-enough segments.
- **Smart status line** — the third line prioritises active operations: historian compacting, dreamer running, pending queue, or an at-rest summary of compartments/facts/memories.
- **No visual gap** — the `<box marginTop={1}>` wrapper that created a blank line between the collapsed header and the status bar is removed.

Under the hood, the bar rendering changed from fixed-character fill (`"█".repeat(w)`) to `flexGrow`-proportional segment boxes with `backgroundColor`, so the bar naturally stretches to the full row width regardless of the sidebar's rendered size.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Magic Context sidebar collapsible with a compact 3‑line overview that frees space while keeping usage visible. Compact bar labels are configurable via `tui.compact_bar` in `magic-context.jsonc`; collapse state persists across restarts and respects `tui.sidebar.collapse_default` until the first manual toggle.

- **New Features**
  - Click the header to toggle collapse/expand (shows ▶/▼); expanded view is unchanged.
  - Collapsed header shows usage vs threshold and token counts (e.g., 47.5% / 65%, 111K / 180K).
  - Compact color‑coded bar fills the full width with a dim “Free” segment; width‑aware labels with optional “Free” suffix and thresholds from `tui.compact_bar` (`label_threshold`, `free_label_threshold`, `show_free_label`).
  - Smart status line prioritizes active work (historian, dreamer, queue), surfaces notes, or shows compartment/fact/memory counts.
  - Added `tui.sidebar.collapse_default` and `tui.compact_bar` defaults to the schema; manual toggles persist via KV and override defaults.

- **Bug Fixes**
  - Respect `tui.sidebar.collapse_default` until the first user toggle using a KV user-set flag.
  - Collapsed header now uses consistent percent formatting via helpers.
  - Status line shows even when token usage is 0; includes session/smart notes counts.
  - Parse and clamp `tui.compact_bar` thresholds to valid ranges; prevent label bleed on narrow segments; add short number‑only label for the Free segment when space is tight.

<sup>Written for commit c6b425e1ff9c01d80dbe48620ed4a2c74e20bbcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/93?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->





