### PR TITLE
test: fix EBUSY database lock failures on Windows during teardown

### DIFF
--- a/packages/cli/src/commands/migrate.test.ts
+++ b/packages/cli/src/commands/migrate.test.ts
@@ -183,7 +183,13 @@ function makeCortexkitDb() {
 
 afterEach(() => {
     for (const db of databases.splice(0)) db.close();
-    for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+    for (const dir of tempDirs.splice(0)) {
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            // Ignore EBUSY on Windows
+        }
+    }
 });
 
 describe("migrateOpenCodeSessionToPi", () => {

--- a/packages/plugin/src/config/index.test.ts
+++ b/packages/plugin/src/config/index.test.ts
@@ -42,8 +42,16 @@ function loadWithUserConfig(configText: string, extraEnv: Record<string, string>
             if (v === undefined) delete process.env[k];
             else process.env[k] = v;
         }
-        rmSync(xdg, { recursive: true, force: true });
-        rmSync(projectDir, { recursive: true, force: true });
+        try {
+            rmSync(xdg, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
+        try {
+            rmSync(projectDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
 }
 
@@ -81,8 +89,16 @@ function loadWithUserAndProjectConfig(
             if (v === undefined) delete process.env[k];
             else process.env[k] = v;
         }
-        rmSync(xdg, { recursive: true, force: true });
-        rmSync(projectDir, { recursive: true, force: true });
+        try {
+            rmSync(xdg, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
+        try {
+            rmSync(projectDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
 }
 

--- a/packages/plugin/src/config/variable.test.ts
+++ b/packages/plugin/src/config/variable.test.ts
@@ -14,7 +14,11 @@ describe("substituteConfigVariables", () => {
     });
 
     afterEach(() => {
-        rmSync(tmpDir, { recursive: true, force: true });
+        try {
+            rmSync(tmpDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
         process.env = { ...ORIGINAL_ENV };
     });
 

--- a/packages/plugin/src/features/magic-context/boundary-execution-cas-race.test.ts
+++ b/packages/plugin/src/features/magic-context/boundary-execution-cas-race.test.ts
@@ -5,6 +5,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "../../shared/sqlite";
+import { closeQuietly } from "../../shared/sqlite-helpers";
 import {
     type DeferredExecutePayload,
     peekDeferredExecutePending,
@@ -50,16 +51,22 @@ function payload(id: string): DeferredExecutePayload {
 describe("deferred execute CAS race", () => {
     it("15. one WAL handle wins set-if-absent and the other no-ops", () => {
         const dir = mkdtempSync(join(tmpdir(), "boundary-exec-race-"));
+        const path = join(dir, "context.db");
+        const a = createRaceDb(path);
+        const b = createRaceDb(path);
         try {
-            const path = join(dir, "context.db");
-            const a = createRaceDb(path);
-            const b = createRaceDb(path);
             const first = setDeferredExecutePendingIfAbsent(a, "s1", payload("a"));
             const second = setDeferredExecutePendingIfAbsent(b, "s1", payload("b"));
             expect([first, second].filter(Boolean)).toHaveLength(1);
             expect(peekDeferredExecutePending(a, "s1")?.id).toBe(first ? "a" : "b");
         } finally {
-            rmSync(dir, { recursive: true, force: true });
+            closeQuietly(a);
+            closeQuietly(b);
+            try {
+                rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+            } catch {
+                // Ignore EBUSY on Windows
+            }
         }
     });
 });

--- a/packages/plugin/src/features/magic-context/compartment-lease.test.ts
+++ b/packages/plugin/src/features/magic-context/compartment-lease.test.ts
@@ -43,10 +43,12 @@ describe("compartment state lease", () => {
         const db = makeDb();
         const first = acquireCompartmentLease(db, "ses", "holder-a");
         expect(first).not.toBeNull();
+
         db.prepare("UPDATE compartment_state_lease SET expires_at = ? WHERE session_id = ?").run(
             Date.now() + 1_000,
             "ses",
         );
+
         const second = acquireCompartmentLease(db, "ses", "holder-a");
         expect(second).not.toBeNull();
         expect(second!.expiresAt).toBeGreaterThan(first!.acquiredAt + 1_000);
@@ -56,10 +58,12 @@ describe("compartment state lease", () => {
     it("lets another holder reclaim an expired lease", () => {
         const db = makeDb();
         expect(acquireCompartmentLease(db, "ses", "holder-a")).not.toBeNull();
+
         db.prepare("UPDATE compartment_state_lease SET expires_at = ? WHERE session_id = ?").run(
             Date.now() - 1,
             "ses",
         );
+
         expect(acquireCompartmentLease(db, "ses", "holder-b")).not.toBeNull();
         expect(isCompartmentLeaseHeld(db, "ses", "holder-b")).toBe(true);
         expect(isCompartmentLeaseHeld(db, "ses", "holder-a")).toBe(false);
@@ -70,6 +74,7 @@ describe("compartment state lease", () => {
         const db = makeDb();
         expect(acquireCompartmentLease(db, "ses", "holder-a")).not.toBeNull();
         expect(renewCompartmentLease(db, "ses", "holder-b")).toBe(false);
+
         db.prepare("UPDATE compartment_state_lease SET expires_at = ? WHERE session_id = ?").run(
             Date.now() - 1,
             "ses",
@@ -81,10 +86,12 @@ describe("compartment state lease", () => {
     it("release is a no-op after another holder reclaims the row", () => {
         const db = makeDb();
         expect(acquireCompartmentLease(db, "ses", "holder-a")).not.toBeNull();
+
         db.prepare("UPDATE compartment_state_lease SET expires_at = ? WHERE session_id = ?").run(
             Date.now() - 1,
             "ses",
         );
+
         expect(acquireCompartmentLease(db, "ses", "holder-b")).not.toBeNull();
         releaseCompartmentLease(db, "ses", "holder-a");
         expect(isCompartmentLeaseHeld(db, "ses", "holder-b")).toBe(true);
@@ -105,7 +112,11 @@ describe("compartment state lease", () => {
         } finally {
             closeQuietly(dbA);
             closeQuietly(dbB);
-            rmSync(dir, { recursive: true, force: true });
+            try {
+                rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+            } catch {
+                // Ignore EBUSY on Windows
+            }
         }
     });
 
@@ -114,10 +125,13 @@ describe("compartment state lease", () => {
         const path = join(dir, "context.db");
         const setup = makeDb(path);
         closeQuietly(setup);
+
         try {
-            const pluginRoot = process.cwd().endsWith("/packages/plugin")
-                ? process.cwd()
-                : join(process.cwd(), "packages", "plugin");
+            const projectRoot = process.cwd().includes("packages")
+                ? join(process.cwd(), "..", "..")
+                : process.cwd();
+            const pluginRoot = join(projectRoot, "packages", "plugin");
+
             const script = `
                 const sqlite = await import(${JSON.stringify(`file://${pluginRoot}/src/shared/sqlite.ts`)});
                 const storageDb = await import(${JSON.stringify(`file://${pluginRoot}/src/features/magic-context/storage-db.ts`)});
@@ -128,13 +142,18 @@ describe("compartment state lease", () => {
                 db.close();
                 console.log(JSON.stringify({ ok }));
             `;
+
             const [a, b] = await Promise.all([
                 $`bun -e ${script} holder-a`.json() as Promise<{ ok: boolean }>,
                 $`bun -e ${script} holder-b`.json() as Promise<{ ok: boolean }>,
             ]);
             expect([a.ok, b.ok].filter(Boolean)).toHaveLength(1);
         } finally {
-            rmSync(dir, { recursive: true, force: true });
+            try {
+                rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+            } catch {
+                // Ignore EBUSY on Windows
+            }
         }
     });
 });

--- a/packages/plugin/src/features/magic-context/compartment-storage-v6.test.ts
+++ b/packages/plugin/src/features/magic-context/compartment-storage-v6.test.ts
@@ -16,7 +16,13 @@ function useTempDataHome(prefix: string): string {
 
 afterEach(() => {
     closeDatabase();
-    for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+    for (const dir of tempDirs) {
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            // Ignore EBUSY on Windows
+        }
+    }
     tempDirs.length = 0;
     process.env.XDG_DATA_HOME = undefined;
 });

--- a/packages/plugin/src/features/magic-context/compression-depth-storage.test.ts
+++ b/packages/plugin/src/features/magic-context/compression-depth-storage.test.ts
@@ -31,7 +31,11 @@ afterEach(() => {
     process.env.XDG_DATA_HOME = originalXdgDataHome;
 
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/features/magic-context/key-files/project-key-files.test.ts
+++ b/packages/plugin/src/features/magic-context/key-files/project-key-files.test.ts
@@ -30,7 +30,12 @@ const originalHome = process.env.HOME;
 afterEach(() => {
     setAftAvailabilityOverride(null);
     process.env.HOME = originalHome;
-    for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+    for (const dir of tempDirs)
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     tempDirs.length = 0;
 });
 

--- a/packages/plugin/src/features/magic-context/memory/embedding.test.ts
+++ b/packages/plugin/src/features/magic-context/memory/embedding.test.ts
@@ -132,7 +132,11 @@ describe("embedding module", () => {
             _resetEmbeddingSweepGuard();
             process.env.XDG_DATA_HOME = originalXdgDataHome;
             for (const dir of tempDirs) {
-                rmSync(dir, { recursive: true, force: true });
+                try {
+                    rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+                } catch {
+                    /* Ignore EBUSY on Windows */
+                }
             }
             tempDirs.length = 0;
         });

--- a/packages/plugin/src/features/magic-context/migrations-v11.test.ts
+++ b/packages/plugin/src/features/magic-context/migrations-v11.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="bun-types" />
+
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -27,7 +29,13 @@ function useTempDataHome(prefix: string): string {
 
 afterEach(() => {
     closeDatabase();
-    for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+    for (const dir of tempDirs) {
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            // Ignore EBUSY on Windows where closeDatabase doesn't synchronously release locks
+        }
+    }
     tempDirs.length = 0;
     process.env.XDG_DATA_HOME = undefined;
 });

--- a/packages/plugin/src/features/magic-context/migrations-v12.test.ts
+++ b/packages/plugin/src/features/magic-context/migrations-v12.test.ts
@@ -21,7 +21,13 @@ function count(db: Database, table: string): number {
 
 afterEach(() => {
     closeDatabase();
-    for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+    for (const dir of tempDirs) {
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            // Ignore EBUSY on Windows
+        }
+    }
     tempDirs.length = 0;
     process.env.XDG_DATA_HOME = undefined;
 });

--- a/packages/plugin/src/features/magic-context/migrations-v13.test.ts
+++ b/packages/plugin/src/features/magic-context/migrations-v13.test.ts
@@ -22,7 +22,13 @@ function useTempDataHome(prefix: string): string {
 
 afterEach(() => {
     closeDatabase();
-    for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+    for (const dir of tempDirs) {
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            // Ignore EBUSY on Windows
+        }
+    }
     tempDirs.length = 0;
     process.env.XDG_DATA_HOME = undefined;
 });

--- a/packages/plugin/src/features/magic-context/migrations-v16.test.ts
+++ b/packages/plugin/src/features/magic-context/migrations-v16.test.ts
@@ -14,7 +14,13 @@ function useTempDataHome(prefix: string): void {
 
 afterEach(() => {
     closeDatabase();
-    for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+    for (const dir of tempDirs) {
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            // Ignore EBUSY on Windows
+        }
+    }
     tempDirs.length = 0;
     process.env.XDG_DATA_HOME = undefined;
 });

--- a/packages/plugin/src/features/magic-context/migrations-v18-pi-marker.test.ts
+++ b/packages/plugin/src/features/magic-context/migrations-v18-pi-marker.test.ts
@@ -21,7 +21,13 @@ function useTempDataHome(prefix: string): void {
 
 afterEach(() => {
     closeDatabase();
-    for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+    for (const dir of tempDirs) {
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            // Ignore EBUSY on Windows
+        }
+    }
     tempDirs.length = 0;
     process.env.XDG_DATA_HOME = undefined;
 });

--- a/packages/plugin/src/features/magic-context/migrations-v20.test.ts
+++ b/packages/plugin/src/features/magic-context/migrations-v20.test.ts
@@ -21,7 +21,11 @@ describe("migration v20", () => {
         } finally {
             closeDatabase();
             process.env.XDG_DATA_HOME = undefined;
-            rmSync(dir, { recursive: true, force: true });
+            try {
+                rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+            } catch {
+                // Ignore EBUSY on Windows
+            }
         }
     });
 });

--- a/packages/plugin/src/features/magic-context/migrations-v21.test.ts
+++ b/packages/plugin/src/features/magic-context/migrations-v21.test.ts
@@ -20,7 +20,11 @@ describe("migration v21", () => {
         } finally {
             closeDatabase();
             process.env.XDG_DATA_HOME = undefined;
-            rmSync(dir, { recursive: true, force: true });
+            try {
+                rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+            } catch {
+                // Ignore EBUSY on Windows
+            }
         }
     });
 });

--- a/packages/plugin/src/features/magic-context/project-embedding-registry.test.ts
+++ b/packages/plugin/src/features/magic-context/project-embedding-registry.test.ts
@@ -64,7 +64,11 @@ describe("project embedding registry", () => {
         closeDatabase();
         process.env.XDG_DATA_HOME = originalXdgDataHome;
         for (const dir of tempDirs) {
-            rmSync(dir, { recursive: true, force: true });
+            try {
+                rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+            } catch {
+                /* Ignore EBUSY on Windows */
+            }
         }
         tempDirs.length = 0;
     });

--- a/packages/plugin/src/features/magic-context/resolve-subagent-fallback.test.ts
+++ b/packages/plugin/src/features/magic-context/resolve-subagent-fallback.test.ts
@@ -51,7 +51,11 @@ describe("resolveIsSubagentFromOpenCodeDb", () => {
         } else {
             process.env.XDG_DATA_HOME = originalXdg;
         }
-        rmSync(tempDir, { recursive: true, force: true });
+        try {
+            rmSync(tempDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     });
 
     it("returns true for a child session with a non-empty parent_id", () => {

--- a/packages/plugin/src/features/magic-context/sticky-injection-cas-race.test.ts
+++ b/packages/plugin/src/features/magic-context/sticky-injection-cas-race.test.ts
@@ -36,7 +36,11 @@ describe("sticky-injection CAS helpers", () => {
                 { messageId: "m2", text: "text-2" },
             ]);
         } finally {
-            rmSync(dir, { recursive: true, force: true });
+            try {
+                rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+            } catch {
+                /* Ignore EBUSY on Windows */
+            }
         }
     });
 
@@ -51,7 +55,11 @@ describe("sticky-injection CAS helpers", () => {
             expect(pruneNoteNudgeAnchors(a, "s1", new Set(["m2"]))).toBe(1);
             expect(getNoteNudgeAnchors(b, "s1")).toEqual([{ messageId: "m2", text: "text-2" }]);
         } finally {
-            rmSync(dir, { recursive: true, force: true });
+            try {
+                rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+            } catch {
+                /* Ignore EBUSY on Windows */
+            }
         }
     });
 
@@ -70,7 +78,11 @@ describe("sticky-injection CAS helpers", () => {
             });
             expect(getNoteNudgeAnchors(db, "s1")).toEqual([{ messageId: "m1", text: "text-1" }]);
         } finally {
-            rmSync(dir, { recursive: true, force: true });
+            try {
+                rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+            } catch {
+                /* Ignore EBUSY on Windows */
+            }
         }
     });
 
@@ -93,7 +105,11 @@ describe("sticky-injection CAS helpers", () => {
                 }),
             ).toEqual({ ok: true, kind: "already-present", decision: stored });
         } finally {
-            rmSync(dir, { recursive: true, force: true });
+            try {
+                rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+            } catch {
+                /* Ignore EBUSY on Windows */
+            }
         }
     });
 });

--- a/packages/plugin/src/features/magic-context/storage-db-migration.test.ts
+++ b/packages/plugin/src/features/magic-context/storage-db-migration.test.ts
@@ -38,7 +38,11 @@ describe("storage-db legacy migration", () => {
             delete process.env.XDG_DATA_HOME;
         }
         try {
-            rmSync(tmpRoot, { recursive: true, force: true });
+            try {
+                rmSync(tmpRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+            } catch {
+                /* Ignore EBUSY on Windows */
+            }
         } catch {
             // Non-fatal — tests on locked Windows file handles can leave temp
             // dirs that the OS will clean up later.

--- a/packages/plugin/src/features/magic-context/storage-db.test.ts
+++ b/packages/plugin/src/features/magic-context/storage-db.test.ts
@@ -34,7 +34,11 @@ afterEach(() => {
     process.env.XDG_DATA_HOME = originalXdgDataHome;
 
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            // Ignore EBUSY on Windows
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/features/magic-context/storage.test.ts
+++ b/packages/plugin/src/features/magic-context/storage.test.ts
@@ -61,7 +61,11 @@ afterEach(() => {
     process.env.XDG_DATA_HOME = originalXdgDataHome;
 
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            // Ignore EBUSY on Windows
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/features/magic-context/tagger-recovery.test.ts
+++ b/packages/plugin/src/features/magic-context/tagger-recovery.test.ts
@@ -414,7 +414,11 @@ describe("initFromDb signature cache", () => {
                 dbA.close();
             }
         } finally {
-            rmSync(tmpDir, { recursive: true, force: true });
+            try {
+                rmSync(tmpDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+            } catch {
+                /* Ignore EBUSY on Windows */
+            }
         }
     });
 

--- a/packages/plugin/src/features/magic-context/tool-owner-backfill.test.ts
+++ b/packages/plugin/src/features/magic-context/tool-owner-backfill.test.ts
@@ -27,7 +27,11 @@ const originalXdgDataHome = process.env.XDG_DATA_HOME;
 afterEach(() => {
     process.env.XDG_DATA_HOME = originalXdgDataHome;
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/auto-update-checker/index.test.ts
+++ b/packages/plugin/src/hooks/auto-update-checker/index.test.ts
@@ -61,7 +61,11 @@ afterEach(() => {
         const dir = tempDirs.pop();
         if (!dir) continue;
         try {
-            rmSync(dir, { recursive: true, force: true });
+            try {
+                rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+            } catch {
+                /* Ignore EBUSY on Windows */
+            }
         } catch {
             // Best-effort cleanup
         }

--- a/packages/plugin/src/hooks/magic-context/apply-operations.tool-drop.test.ts
+++ b/packages/plugin/src/hooks/magic-context/apply-operations.tool-drop.test.ts
@@ -29,7 +29,11 @@ afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/compaction-marker-consistency.test.ts
+++ b/packages/plugin/src/hooks/magic-context/compaction-marker-consistency.test.ts
@@ -60,7 +60,11 @@ afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            // Ignore EBUSY on Windows
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/compaction-marker-manager.test.ts
+++ b/packages/plugin/src/hooks/magic-context/compaction-marker-manager.test.ts
@@ -98,7 +98,11 @@ afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            // Ignore EBUSY on Windows
+        }
     }
     tempDirs.length = 0;
 });
@@ -255,7 +259,7 @@ describe("applyDeferredCompactionMarker — outcomes", () => {
         // No user message exists at or before the boundary → inject returns
         // null → retryable-failure.
         expect(outcome.kind).toBe("retryable-failure");
-        // Persisted state remains absent (we never wrote a marker)
+        // Persisted state remains absent ( we never wrote a marker)
         const persisted = getPersistedCompactionMarkerState(db, "ses-1");
         expect(persisted).toBeNull();
     });

--- a/packages/plugin/src/hooks/magic-context/compartment-runner-drop-queue.test.ts
+++ b/packages/plugin/src/hooks/magic-context/compartment-runner-drop-queue.test.ts
@@ -37,7 +37,11 @@ afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            // Ignore EBUSY on Windows
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/compartment-runner-timeout.test.ts
+++ b/packages/plugin/src/hooks/magic-context/compartment-runner-timeout.test.ts
@@ -19,7 +19,11 @@ afterEach(() => {
     process.env.XDG_DATA_HOME = originalXdgDataHome;
 
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            // Ignore EBUSY on Windows
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/compartment-runner.test.ts
+++ b/packages/plugin/src/hooks/magic-context/compartment-runner.test.ts
@@ -55,13 +55,21 @@ afterEach(() => {
     process.env.XDG_DATA_HOME = originalXdgDataHome;
 
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            // Ignore EBUSY on Windows
+        }
     }
     tempDirs.length = 0;
 
     // Clean up historian debug dumps created during tests
     const dumpDir = join(tmpdir(), "magic-context-historian");
-    rmSync(dumpDir, { recursive: true, force: true });
+    try {
+        rmSync(dumpDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+    } catch {
+        // Ignore EBUSY on Windows
+    }
 });
 
 describe("executeContextRecomp", () => {

--- a/packages/plugin/src/hooks/magic-context/compartment-trigger.test.ts
+++ b/packages/plugin/src/hooks/magic-context/compartment-trigger.test.ts
@@ -22,7 +22,11 @@ afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/event-handler.test.ts
+++ b/packages/plugin/src/hooks/magic-context/event-handler.test.ts
@@ -53,7 +53,11 @@ afterEach(() => {
     process.env.XDG_DATA_HOME = originalXdgDataHome;
 
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/historian-state-file.test.ts
+++ b/packages/plugin/src/hooks/magic-context/historian-state-file.test.ts
@@ -15,7 +15,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-    rmSync(tempProjectDir, { recursive: true, force: true });
+    try {
+        rmSync(tempProjectDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+    } catch {
+        /* Ignore EBUSY on Windows */
+    }
 });
 
 describe("maybeWriteHistorianStateFile", () => {

--- a/packages/plugin/src/hooks/magic-context/hook.test.ts
+++ b/packages/plugin/src/hooks/magic-context/hook.test.ts
@@ -46,7 +46,11 @@ afterEach(() => {
     process.env.XDG_DATA_HOME = originalXdgDataHome;
 
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/nudger.test.ts
+++ b/packages/plugin/src/hooks/magic-context/nudger.test.ts
@@ -23,7 +23,11 @@ afterEach(() => {
     process.env.XDG_DATA_HOME = originalXdgDataHome;
 
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/read-session-chunk.test.ts
+++ b/packages/plugin/src/hooks/magic-context/read-session-chunk.test.ts
@@ -20,7 +20,11 @@ const originalXdgDataHome = process.env.XDG_DATA_HOME;
 afterEach(() => {
     process.env.XDG_DATA_HOME = originalXdgDataHome;
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/read-session-db.test.ts
+++ b/packages/plugin/src/hooks/magic-context/read-session-db.test.ts
@@ -21,7 +21,11 @@ afterEach(() => {
     closeReadOnlySessionDb();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/system-prompt-hash.test.ts
+++ b/packages/plugin/src/hooks/magic-context/system-prompt-hash.test.ts
@@ -41,7 +41,11 @@ afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/tag-messages-collision.test.ts
+++ b/packages/plugin/src/hooks/magic-context/tag-messages-collision.test.ts
@@ -30,7 +30,11 @@ afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/tool-input-preservation.test.ts
+++ b/packages/plugin/src/hooks/magic-context/tool-input-preservation.test.ts
@@ -15,7 +15,11 @@ afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/transform-cache-busting-signals.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform-cache-busting-signals.test.ts
@@ -79,7 +79,11 @@ afterEach(() => {
     process.env.XDG_DATA_HOME = originalXdgDataHome;
 
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/transform-compartment-phase.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform-compartment-phase.test.ts
@@ -84,7 +84,12 @@ beforeEach(() => {
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
-    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+    if (tempDir)
+        try {
+            rmSync(tempDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
 });
 
 describe("runCompartmentPhase - 95% emergency notification idempotency", () => {

--- a/packages/plugin/src/hooks/magic-context/transform-context-state.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform-context-state.test.ts
@@ -20,7 +20,11 @@ afterEach(() => {
     process.env.XDG_DATA_HOME = originalXdgDataHome;
 
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/transform-heuristic-cleanup-persistence.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform-heuristic-cleanup-persistence.test.ts
@@ -118,7 +118,11 @@ afterEach(() => {
     process.env.XDG_DATA_HOME = originalXdgDataHome;
 
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/transform-index-staleness.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform-index-staleness.test.ts
@@ -38,7 +38,11 @@ afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/transform-nudge-cache.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform-nudge-cache.test.ts
@@ -35,7 +35,11 @@ afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/transform-operations.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform-operations.test.ts
@@ -33,7 +33,11 @@ afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            // Ignore EBUSY on Windows
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/transform-todo-state.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform-todo-state.test.ts
@@ -43,7 +43,12 @@ function useTempDataHome(prefix: string): void {
 
 afterEach(() => {
     closeDatabase();
-    for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+    for (const dir of tempDirs)
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     tempDirs.length = 0;
     process.env.XDG_DATA_HOME = undefined;
 });

--- a/packages/plugin/src/hooks/magic-context/transform.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform.test.ts
@@ -77,7 +77,11 @@ afterEach(() => {
     else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
 
     for (const dir of tempDirs) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/shared/announcement.test.ts
+++ b/packages/plugin/src/shared/announcement.test.ts
@@ -35,7 +35,8 @@ afterEach(() => {
         process.env.XDG_DATA_HOME = originalXdg;
     }
     try {
-        fs.rmSync(tmpRoot, { recursive: true, force: true });
+        // maxRetries/retryDelay ride out transient EBUSY/EPERM on Windows.
+        fs.rmSync(tmpRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
     } catch {
         // best-effort
     }

--- a/packages/plugin/src/shared/conflict-detector.test.ts
+++ b/packages/plugin/src/shared/conflict-detector.test.ts
@@ -46,8 +46,21 @@ describe("detectConflicts", () => {
             else process.env[k] = v;
         }
         // Test directories live under tmpdir(); cleanup is best-effort.
-        rmSync(projectDir, { recursive: true, force: true });
-        rmSync(userConfigDir, { recursive: true, force: true });
+        try {
+            rmSync(projectDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
+        try {
+            rmSync(userConfigDir, {
+                recursive: true,
+                force: true,
+                maxRetries: 10,
+                retryDelay: 100,
+            });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     });
 
     function writeProjectConfig(plugins: Array<string | [string, unknown]>): void {

--- a/packages/plugin/src/shared/conflict-fixer.test.ts
+++ b/packages/plugin/src/shared/conflict-fixer.test.ts
@@ -38,7 +38,11 @@ describe("fixConflicts", () => {
             if (value === undefined) delete process.env[key];
             else process.env[key] = value;
         }
-        rmSync(root, { recursive: true, force: true });
+        try {
+            rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     });
 
     it("preserves JSONC comments and tuple plugin entries while removing canonical DCP", () => {

--- a/packages/plugin/src/shared/models-dev-cache.test.ts
+++ b/packages/plugin/src/shared/models-dev-cache.test.ts
@@ -39,7 +39,11 @@ describe("models-dev-cache", () => {
             if (v === undefined) delete process.env[k];
             else process.env[k] = v;
         }
-        rmSync(tempDir, { recursive: true, force: true });
+        try {
+            rmSync(tempDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
         clearModelsDevCache();
     });
 

--- a/packages/plugin/src/shared/opencode-compaction-detector.test.ts
+++ b/packages/plugin/src/shared/opencode-compaction-detector.test.ts
@@ -18,7 +18,11 @@ describe("opencode-compaction-detector", () => {
     });
 
     afterEach(() => {
-        rmSync(tmpDir, { recursive: true, force: true });
+        try {
+            rmSync(tmpDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
         delete process.env.OPENCODE_DISABLE_AUTOCOMPACT;
     });
 
@@ -30,7 +34,11 @@ describe("opencode-compaction-detector", () => {
             const result = isOpenCodeAutoCompactionEnabled(emptyDir);
 
             expect(result).toBe(true);
-            rmSync(emptyDir, { recursive: true, force: true });
+            try {
+                rmSync(emptyDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+            } catch {
+                /* Ignore EBUSY on Windows */
+            }
         });
     });
 

--- a/packages/plugin/src/shared/rpc-client.test.ts
+++ b/packages/plugin/src/shared/rpc-client.test.ts
@@ -20,7 +20,11 @@ afterEach(async () => {
         await server.close();
     }
     for (const dir of tempDirs.splice(0)) {
-        rmSync(dir, { recursive: true, force: true });
+        try {
+            rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+        } catch {
+            /* Ignore EBUSY on Windows */
+        }
     }
 });
 


### PR DESCRIPTION
Fixes https://github.com/cortexkit/magic-context/issues/102

**Bug Description**
The test suite intermittently fails on Windows environments with `EBUSY: resource busy or locked` errors during teardown. This occurs because SQLite file handles can take a moment to be completely released by the operating system after database connections are closed. Due to strict file locking on Windows, attempts to synchronously delete temporary directories containing these SQLite databases using `rmSync(dir, { recursive: true, force: true })` fail.

**Fix Details**
I wrapped all `rmSync` calls found in `afterEach` teardown hooks across the project's test suites within `try/catch` blocks that silently ignore the error on Windows. Additionally, I modified the 
`rmSync` options to include `maxRetries: 10` and `retryDelay: 100`, providing a small grace period for any lingering SQLite file handles to release gracefully before aborting.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened test teardown on Windows to prevent intermittent EBUSY errors from lingering SQLite locks. Cleanup now tolerates delayed handle release and removes temp dirs more reliably across the suite.

- Bug Fixes
  - Wrapped all rmSync teardowns in try/catch with { maxRetries: 10, retryDelay: 100 }, including historian debug dump cleanup.
  - Closed SQLite handles explicitly in race/lease tests using closeQuietly before cleanup.
  - Fixed plugin root path detection in `compartment-lease.test.ts` so the script runs from any cwd.
  - Added Bun types reference in `migrations-v11.test.ts` for the Bun test runner.

<sup>Written for commit 8d060c23b41fc18c735c7094fba33f0980bec731. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens test teardown across 56 test files to prevent intermittent `EBUSY: resource busy or locked` failures on Windows, where SQLite file handles may not be fully released before `rmSync` attempts to delete the temp directory.

- Wraps every `rmSync` in `afterEach`/`finally` teardown blocks with `{ maxRetries: 10, retryDelay: 100 }` and an outer `try/catch` to tolerate residual Windows file locks.
- Adds explicit `closeQuietly` calls before cleanup in `boundary-execution-cas-race.test.ts` and lease-related tests that open multiple DB handles, and fixes the `pluginRoot` path computation in `compartment-lease.test.ts` to work cross-platform.
- Adds a `/// <reference types="bun-types" />` directive to `migrations-v11.test.ts` for the Bun test runner type resolution.
</details>


<h3>Confidence Score: 3/5</h3>

Safe to merge for most test files, but sticky-injection-cas-race.test.ts still leaves database handles open before cleanup, so Windows EBUSY failures are not fully resolved there.

The majority of the 56 changed files receive the correct treatment — closing explicit DB handles and wrapping rmSync with retries. However, sticky-injection-cas-race.test.ts opens two WAL handles (a and b) in tests 1 and 2 but never calls closeQuietly on them before rmSync. Those open handles are the direct source of EBUSY on Windows, and without explicit closure the retry loop may still exhaust its attempts and silently leak the temp directory. The boundary-execution-cas-race.test.ts file in the same PR shows the intended fix pattern, making the omission in sticky-injection an inconsistency that will leave intermittent failures on Windows for those specific tests.

packages/plugin/src/features/magic-context/sticky-injection-cas-race.test.ts needs closeQuietly calls for handles a and b before rmSync in tests 1 and 2 (and db in tests 3 and 4).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/plugin/src/features/magic-context/sticky-injection-cas-race.test.ts | Added try/catch + maxRetries to all four rmSync teardowns, but missing closeQuietly for database handles a and b in tests 1 and 2 — open handles are the root cause of EBUSY, so cleanup may still fail on Windows. |
| packages/plugin/src/features/magic-context/boundary-execution-cas-race.test.ts | Correctly moves DB handle creation before try block, adds closeQuietly(a/b) in finally, and wraps rmSync with maxRetries/retryDelay inside try/catch — the right pattern for Windows EBUSY avoidance. |
| packages/plugin/src/features/magic-context/compartment-lease.test.ts | Adds closeQuietly and retry-guarded rmSync in teardown; replaces endsWith('/packages/plugin') with includes('packages') path detection to fix Windows path separator — the includes check is a substring match that could resolve incorrectly for unusual checkout paths. |
| packages/plugin/src/features/magic-context/migrations-v11.test.ts | Adds bun-types reference directive and wraps afterEach rmSync with maxRetries/retryDelay inside try/catch — straightforward and correct. |
| packages/plugin/src/hooks/magic-context/compartment-runner.test.ts | Wraps both rmSync calls (temp dirs and historian debug dump) with maxRetries/retryDelay inside try/catch — correct pattern. |
| packages/plugin/src/config/index.test.ts | Splits the two sequential rmSync calls into separate try/catch blocks so a failure on xdg cleanup doesn't prevent projectDir cleanup — correct defensive improvement. |
| packages/plugin/src/shared/conflict-detector.test.ts | Same pattern as config/index.test.ts — independent try/catch blocks for each rmSync call with maxRetries/retryDelay. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/plugin/src/features/magic-context/sticky-injection-cas-race.test.ts`, line 26-44 ([link](https://github.com/cortexkit/magic-context/blob/8d060c23b41fc18c735c7094fba33f0980bec731/packages/plugin/src/features/magic-context/sticky-injection-cas-race.test.ts#L26-L44)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing `closeQuietly` before `rmSync` — EBUSY still likely on Windows**

   The two database handles `a` and `b` opened inside the `try` block are never explicitly closed before `rmSync` attempts to delete the directory. On Windows, SQLite WAL handles hold kernel file locks until explicitly released, so these open handles are the direct cause of EBUSY — the same root cause that `closeQuietly` was added to fix in the parallel `boundary-execution-cas-race.test.ts`. The `try/catch` on `rmSync` silences the error but leaves the temp directory behind every run; with 10 retries at 100 ms each, the GC _might_ collect the handles in time, but this is not guaranteed and differs from the explicit-close pattern used elsewhere in this PR.

   Tests 1 and 2 ("two WAL handles append…" and "append plus prune…") both open `a` and `b` via `createRaceDb` and leave them open. Tests 3 and 4 use a single `db` handle that is similarly unclosed.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["test: fix EBUSY database lock failures o..."](https://github.com/cortexkit/magic-context/commit/8d060c23b41fc18c735c7094fba33f0980bec731) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35109373)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->