### PR TITLE
allow primary agents to list and update memories

### DIFF
--- a/packages/plugin/src/plugin/tool-registry.ts
+++ b/packages/plugin/src/plugin/tool-registry.ts
@@ -82,7 +82,7 @@ export function createToolRegistry(args: {
             db,
             resolveProjectPath,
             ensureProjectRegistered: ensureProjectRegisteredFromOpenCodeDirectory,
-            allowedActions: ["write", "delete"],
+            allowedActions: ["write", "delete", "list", "update"],
         }),
     };
 

--- a/packages/plugin/src/tools/ctx-memory/types.ts
+++ b/packages/plugin/src/tools/ctx-memory/types.ts
@@ -1,12 +1,10 @@
 import type { MemorySourceType } from "../../features/magic-context/memory";
 import type { Database } from "../../shared/sqlite";
 
-export const CTX_MEMORY_ACTIONS = ["write", "delete"] as const;
+export const CTX_MEMORY_ACTIONS = ["write", "delete", "list", "update"] as const;
 
 export const CTX_MEMORY_DREAMER_ACTIONS = [
     ...CTX_MEMORY_ACTIONS,
-    "list",
-    "update",
     "merge",
     "archive",
 ] as const;


### PR DESCRIPTION
list was locked behind a dreamer-only gate alongside update/merge/archive because the designer grouped all maintenance actions together. But list is purely read-only inspection -- blocking it while granting delete meant you could destroy what you couldnt see. update is also less destructive than delete (already granted), and primary agents discover stale or wrong facts in-session without waiting hours for the dreamer to rotate around.

Moved list and update from CTX_MEMORY_DREAMER_ACTIONS to CTX_MEMORY_ACTIONS. CTX_MEMORY_DREAMER_ACTIONS still spreads CTX_MEMORY_ACTIONS so the dreamer retains access to everything.

Test results: 734 pass / 102 fail / 83 errors -- unchanged from master (102 pre-existing failures).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782453891&installation_id=135454708&pr_number=110&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F110&signature=0a8737e8b0115ed5af88fa2cb3fd714ecf3c5ccb7af231541f1e0fffba9abd06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Primary agents can now list and update memories. This lets them inspect and fix facts during a session without waiting on the dreamer.

- New Features
  - Moved `list` and `update` from `CTX_MEMORY_DREAMER_ACTIONS` to `CTX_MEMORY_ACTIONS`.
  - Updated plugin tool registry to allow `["write", "delete", "list", "update"]` for primary agents.

<sup>Written for commit 668908a246494b4f9fa82065c43f89ccee705aba. Summary will update on new commits. <a href="https://cubic.dev/pr/cortexkit/magic-context/pull/110?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

