### PR TITLE
fix: inject WASM ONNX runtime for Bun to prevent NAPI fatal crash

### DIFF
--- a/packages/plugin/src/features/magic-context/memory/embedding-local.ts
+++ b/packages/plugin/src/features/magic-context/memory/embedding-local.ts
@@ -110,12 +110,11 @@ function startLockHeartbeat(lockPath: string): () => void {
  *
  * Why this exists:
  *   `@huggingface/transformers@4.x` does a top-level static `import "onnxruntime-node"`.
- *   On Electron Desktop (e.g. OpenCode Desktop's main process), that native
- *   `.node` binary fails to load for several environmental reasons — missing
- *   Visual C++ Redistributables on Windows, ASAR archive layout issues,
- *   onnxruntime's own dependency DLLs not being resolvable. The failure
- *   propagates up the import chain and Node reports it as `ERR_MODULE_NOT_FOUND`
- *   targeting `transformers.node.mjs`, even though that file exists.
+ *   On runtimes where the native `.node` binary fails to load — Electron
+ *   Desktop (missing Visual C++ on Windows, ASAR layout issues, ABI
+ *   mismatches) and **Bun** (incomplete N-API compatibility layer that
+ *   panics on `napi_create_error`, see issue #95) — the failure propagates
+ *   up the import chain and crashes the host process.
  *
  *   transformers.js exposes `Symbol.for("onnxruntime")` as an override hook
  *   (added in 3.4.x via PR #1231). If that global symbol is set before the
@@ -124,29 +123,43 @@ function startLockHeartbeat(lockPath: string): () => void {
  *
  *   `onnxruntime-web` (WASM backend) is already a direct dependency of
  *   `@huggingface/transformers`, so it's installed alongside `onnxruntime-node`
- *   with no extra package needed. WASM is slower than native CPU on Node/Bun
- *   but on Electron Desktop it's the only path that actually loads.
+ *   with no extra package needed. WASM is slower than native CPU on Node but
+ *   on Electron Desktop and Bun it's the only path that loads reliably.
  *
- * Why only Electron:
- *   Plain Node and Bun runtimes (Pi, terminal OpenCode, dashboard backend)
- *   load `onnxruntime-node` correctly. We don't want to regress those to WASM.
- *   `process.versions.electron` is the canonical check — it's only present
- *   inside Electron processes.
+ * Why Electron and Bun:
+ *   - Electron: `.node` binaries compiled for plain Node may have wrong
+ *     NODE_MODULE_VERSION; ASAR archives can hide DLL dependencies.
+ *   - Bun: its N-API compatibility layer is incomplete — `onnxruntime-node`
+ *     calls `napi_create_error` which triggers Bun's fatal panic
+ *     (`NAPI FATAL ERROR: Error::New napi_create_error`, issue #95).
+ *   - Plain Node (Pi, terminal OpenCode, dashboard backend): loads
+ *     `onnxruntime-node` correctly — we don't want to regress those to WASM.
+ *
+ * Detection:
+ *   - `process.versions.electron` is set inside Electron processes.
+ *   - `process.versions.bun` is set inside Bun processes.
+ *   - Neither is set in plain Node.
  *
  * Refs:
- *   - https://github.com/cortexkit/magic-context/issues/78
+ *   - https://github.com/cortexkit/magic-context/issues/78 (Electron)
+ *   - https://github.com/cortexkit/magic-context/issues/95 (Bun NAPI crash)
  *   - https://github.com/huggingface/transformers.js/pull/1231 (ORT_SYMBOL)
  *   - https://github.com/huggingface/transformers.js/issues/1240 (Electron picks wrong ORT)
  */
-async function injectWasmOrtForElectron(): Promise<boolean> {
-    if (typeof process === "undefined" || !process.versions?.electron) {
+async function injectWasmOrtIfNeeded(): Promise<boolean> {
+    const isElectron = typeof process !== "undefined" && !!process.versions?.electron;
+    const isBun = typeof process !== "undefined" && typeof process.versions?.bun === "string";
+
+    if (!isElectron && !isBun) {
         return false;
     }
+
+    const runtimeLabel = isElectron ? "Electron" : "Bun";
 
     try {
         // Non-literal specifier — same trick we use for `@huggingface/transformers`
         // to keep Bun's static analyzer from eagerly probing the package at plugin
-        // load time. We need lazy resolution because non-Electron runtimes never
+        // load time. We need lazy resolution because plain-Node runtimes never
         // need onnxruntime-web at all. See issue #4.
         const ortWebSpec = `onnxruntime-${"web"}`;
         const ortWeb = (await import(ortWebSpec)) as {
@@ -184,7 +197,7 @@ async function injectWasmOrtForElectron(): Promise<boolean> {
         // instead of its own native selection logic.
         (globalThis as Record<symbol, unknown>)[Symbol.for("onnxruntime")] = ortWeb;
         log(
-            "[magic-context] Electron detected — using onnxruntime-web (WASM) for embeddings (bypasses onnxruntime-node native load)",
+            `[magic-context] ${runtimeLabel} detected — using onnxruntime-web (WASM) for embeddings (bypasses onnxruntime-node native load)`,
         );
         return true;
     } catch (error) {
@@ -193,7 +206,7 @@ async function injectWasmOrtForElectron(): Promise<boolean> {
         // native load. That will likely fail too, but the error will be the
         // user's actual problem rather than something masked by our shim.
         log(
-            "[magic-context] failed to inject onnxruntime-web for Electron — letting transformers fall back to native:",
+            `[magic-context] failed to inject onnxruntime-web for ${runtimeLabel} — letting transformers fall back to native:`,
             error instanceof Error ? error.message : String(error),
         );
         return false;
@@ -355,13 +368,15 @@ export class LocalEmbeddingProvider implements EmbeddingProvider {
                     return;
                 }
 
-                // Pre-inject WASM ORT runtime for Electron Desktop. This MUST run
-                // before the first `await import("@huggingface/transformers")` below
-                // — transformers.js reads `Symbol.for("onnxruntime")` at module
+                // Pre-inject WASM ORT runtime for Electron Desktop and Bun.
+                // This MUST run before the first `await import("@huggingface/transformers")`
+                // below — transformers.js reads `Symbol.for("onnxruntime")` at module
                 // evaluation time and uses whatever we provide instead of doing its
-                // own native-vs-web backend selection. No-op on plain Node/Bun.
-                // See: https://github.com/cortexkit/magic-context/issues/78
-                await injectWasmOrtForElectron();
+                // own native-vs-web backend selection.
+                // - Electron: avoids ABI mismatch / ASAR issues (issue #78).
+                // - Bun: avoids N-API fatal panic in onnxruntime-node (issue #95).
+                // No-op on plain Node (Pi, terminal OpenCode, dashboard).
+                await injectWasmOrtIfNeeded();
 
                 // Non-literal import specifier prevents Bun from eagerly resolving
                 // @huggingface/transformers at plugin load time. Desktop sidecar spawns


### PR DESCRIPTION
## Problem

opencode crashes with `NAPI FATAL ERROR: Error::New napi_create_error` when `@cortexkit/opencode-magic-context` is enabled on macOS arm64 (issue #95). The crash is triggered by `onnxruntime-node` (native N-API addon) hitting an incomplete N-API code path in Bun.

## Root cause

`@huggingface/transformers@4.x` statically imports `onnxruntime-node`. Under Bun, the native N-API binding calls `napi_create_error` which triggers Bun's fatal panic, crashing the entire host process. The crash is intermittent (happens "after running for a while") and depends on specific N-API error paths.

## Fix

Extend the existing WASM ONNX injection (`injectWasmOrtForElectron`, added for issue #78) to also activate under Bun. Both runtimes now get `onnxruntime-web` (WASM backend) instead of the native `onnxruntime-node`, while plain Node continues using the faster native backend.

**Detection:** `process.versions.bun` (Bun) || `process.versions.electron` (Electron) → inject WASM. Neither set (plain Node) → no-op.

## Verification

- ✅ `onnxruntime-web` loads and runs inference under Bun
- ✅ `Symbol.for("onnxruntime")` injection makes transformers.js use WASM backend
- ✅ Concurrent model loading works (5 parallel sessions)
- ✅ TypeScript typecheck passes
- ✅ Lint passes
- ✅ Build passes

## Trade-off

WASM backend is slower than native CPU, but it's the only reliable path under Bun. The native `onnxruntime-node` cannot safely load due to Bun's N-API limitations.

Closes #95

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782917537&installation_id=135454708&pr_number=124&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F124&signature=b2cf6454a080af9dfa0fa30f630da7b244ceb3a64cda390c609d5d0f2abfe230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Bun and Electron to `onnxruntime-web` (WASM) for embeddings to avoid `onnxruntime-node` N-API crashes. Plain Node keeps the native backend; closes #95.

- **Bug Fixes**
  - Injects WASM via `Symbol.for("onnxruntime")` when `process.versions.bun` or `process.versions.electron` is set; no-op on plain Node.
  - Prevents Bun panic (`NAPI FATAL ERROR: Error::New napi_create_error`) and Electron native load issues; falls back to native if injection fails.

<sup>Written for commit 2f58845d870674e0333521e3b6a3dc08e5eb2368. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

