### PR TITLE
test(transform): pad the newest-20 skeleton window for the legacy full-drop expectation

### DIFF
--- a/packages/plugin/src/hooks/magic-context/transform.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform.test.ts
@@ -26,6 +26,7 @@ import {
     getTagById,
     getTagsBySession,
     incrementHistorianFailure,
+    insertTag,
     loadProtectedTailMeta,
     openDatabase,
     queuePendingOp,
@@ -690,6 +691,15 @@ describe("createTransform", () => {
         await transform({}, { messages: firstPass });
 
         const db = openDatabase();
+        // Push the real tool tag out of the newest-20 skeleton window (the
+        // db7bc0a tool-skeleton change keeps a truncated tool_use/tool_result
+        // pair for drops within that window) so this test keeps exercising
+        // the FULL-removal path it documents. Mirrors padSkeletonWindow in
+        // apply-operations.tool-drop.test.ts — upstream updated that file's
+        // tests for the new behavior but missed this one.
+        for (let i = 1; i <= 20; i += 1) {
+            insertTag(db, "ses-1", `call-pad-${i}`, "tool", 10, 2 + i);
+        }
         queuePendingOp(db, "ses-1", 1, "drop");
         queuePendingOp(db, "ses-1", 2, "drop");
         shouldExecute.mockImplementation(() => "execute");


### PR DESCRIPTION
Title: test(transform): pad the newest-20 skeleton window for the legacy full-drop expectation

## Problem

`db7bc0a` (feat(ctx-reduce): keep tool skeletons for drops in the newest-20
window) changed drop semantics — agent drops of a tool call within the newest
20 tool tags now truncate in place instead of full removal — and updated
`apply-operations.tool-drop.test.ts` accordingly via the `padSkeletonWindow`
helper. One older test was missed:

`transform.test.ts › createTransform › applies pending drop operations when scheduler executes`

That test queues drops on a 2-message session, which is trivially inside the
skeleton window, so the dropped tool-only assistant message now survives as a
truncated skeleton and the test's "fully dropped, shell stripped"
expectation (`toHaveLength(1)`) fails.

Reproduced on pristine `master` (4e3635c) in a clean worktree:

| ref | transform.test.ts |
|---|---|
| v0.23.0 | 37 pass / 0 fail |
| master (4e3635c) | 36 pass / 1 fail |

## Fix

Same remediation `db7bc0a` applied to its own file's legacy tests: insert 20
newer tool tags before queueing the drops, pushing the real tag out of the
newest-20 skeleton window so the test keeps exercising the deep-history
FULL-removal path its assertions document. No production code touched;
behavior coverage for the new skeleton path already lives in
`apply-operations.tool-drop.test.ts`.

## Verification

- `bun test src/hooks/magic-context/transform.test.ts` → 37 pass / 0 fail
- full `packages/plugin` suite → 2082 pass / 0 fail (with this one-file change
  on top of master)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783788884&installation_id=135454708&pr_number=138&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F138&signature=b77a81a8dd1382891c1c38c8e6e974251dfc6b06f89b8e64b676f96adee71051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pads the newest-20 skeleton window in `packages/plugin/src/hooks/magic-context/transform.test.ts` by inserting 20 tool tags so the test continues to assert full removal for deep-history drops. Fixes the failing test after the tool-skeleton change; no production code changed.

<sup>Written for commit dc30ca83a06abc28b457b48e92cbd5a0c1f82cba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

