### PR TITLE
docs: explain existing project onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ The wizard auto-detects which harnesses you have (OpenCode, Pi, or both), adds t
 
 **Troubleshooting:** `npx @cortexkit/magic-context@latest doctor` auto-detects your harnesses, checks for conflicts (compaction, OMO hooks, DCP), verifies the plugin and TUI sidebar, runs an integrity check on the database, and fixes what it can. Add `--issue` to file a ready-to-submit bug report.
 
+### Adding Magic Context to an existing project
+
+Magic Context is not limited to greenfield work. Run the setup wizard from the root of the project you already use with OpenCode or Pi, then restart the harness in that same directory so the plugin can attach to the existing project identity. New turns will be captured automatically, and older raw session history is summarized as the historian runs.
+
+If you want to start organizing existing knowledge right away, use `/ctx-recomp` after setup to rebuild compartments from available history and `/ctx-dream` to run dreamer maintenance on demand. The dashboard can also inspect the shared CortexKit database, memories, compartments, and dreamer runs without starting a coding session.
+
 <details>
 <summary><strong>Compatibility with other context-management plugins</strong></summary>
 


### PR DESCRIPTION
## Summary
- document how to add Magic Context to an existing project
- mention `/ctx-recomp`, `/ctx-dream`, and the dashboard for working with existing history and memory

Fixes #76

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783932644&installation_id=135454708&pr_number=146&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F146&signature=ab0b0638aca0f68d0fd22ce3d688b8f685419a5528a37ae8a3eab1955a7e1b92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds README guidance for adding `@cortexkit/magic-context` to existing OpenCode/Pi projects, including running the setup wizard in-place and restarting the harness to attach to the current project identity. Addresses #76 by documenting how to use `/ctx-recomp`, `/ctx-dream`, and the dashboard to organize past history and inspect memories without starting a session.

<sup>Written for commit cbfaa3fbcac1850b94512cdd3a341f4cbbb8490c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a short two-paragraph section to the README explaining how to onboard an existing project rather than starting from scratch, and briefly surfaces `/ctx-recomp`, `/ctx-dream`, and the desktop app as tools for working with pre-existing history.

- The new section covers running the setup wizard in an existing project directory, restarting the harness, and letting the historian process older sessions — accurate and useful context for the target audience.
- Two minor documentation issues are present: the section calls the Desktop app "the dashboard" (inconsistent with the established term used elsewhere), and it recommends `/ctx-dream` without noting the documented OpenCode-only constraint that would affect Pi-only users.
</details>

<h3>Confidence Score: 4/5</h3>

Documentation-only change; no code is modified and there is no risk of runtime regression.

The new section is accurate for the common OpenCode case, but it uses a different name for the Desktop app than the rest of the README and doesn't surface the OpenCode-only requirement for `/ctx-dream`, which could confuse Pi-only users who follow the advice.

README.md — the two-paragraph addition around line 88–92.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Adds a new "Adding Magic Context to an existing project" section; introduces a terminology inconsistency ("dashboard" vs the established "Desktop app") and omits the OpenCode-only constraint on `/ctx-dream`. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Existing project with OpenCode / Pi] --> B["Run setup wizard\nnpx @cortexkit/magic-context@latest setup"]
    B --> C[Wizard configures plugin &\ndisables built-in compaction]
    C --> D[Restart harness in project root]
    D --> E[Plugin attaches to existing project identity]
    E --> F[New turns captured automatically]
    E --> G[Historian summarizes older raw session history]
    F & G --> H{Want to organise existing\nknowledge right away?}
    H -- Yes --> I["/ctx-recomp — rebuild compartments\nfrom available history\n(OpenCode only)"]
    H -- Yes --> J["/ctx-dream — run dreamer\nmaintenance on demand\n(OpenCode only)"]
    H -- No --> K[Desktop app — browse memories,\ncompartments & dreamer runs\nwithout a coding session]
    I & J --> K
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: explain existing project onboardin..."](https://github.com/cortexkit/magic-context/commit/cbfaa3fbcac1850b94512cdd3a341f4cbbb8490c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37387206)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->