### PR TITLE
docs: clarify existing project adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,11 @@ The wizard auto-detects which harnesses you have (OpenCode, Pi, or both), adds t
 
 ### Adding Magic Context to an existing project
 
-Magic Context is not limited to greenfield work. Run the setup wizard from the root of the project you already use with OpenCode or Pi, then restart the harness in that same directory so the plugin can attach to the existing project identity. New turns will be captured automatically, and older raw session history is summarized as the historian runs.
+Magic Context is not limited to greenfield work. Run the setup wizard from the root of the project you already use with OpenCode or Pi, then restart the harness in that same directory so the plugin can attach to the existing project identity. From that point forward, new turns are captured automatically and the historian compartmentalizes the active session as it grows.
 
-If you want to start organizing existing knowledge right away, use `/ctx-recomp` after setup to rebuild compartments from available history and `/ctx-dream` to run dreamer maintenance on demand. The dashboard can also inspect the shared CortexKit database, memories, compartments, and dreamer runs without starting a coding session.
+Magic Context does **not** retroactively import or reprocess OpenCode or Pi sessions that happened before it was installed. Those past conversations are not backfilled into compartments. What builds up across an existing project from day one includes project memories, dreamer-maintained docs, key files, and other context captured after installation.
+
+If you want to seed knowledge from older work, add the important facts explicitly with `ctx_memory`, write a short project note in the repo, or keep working in the project and let the historian and dreamer promote recurring facts over time. Use `/ctx-recomp` when you need to rebuild Magic Context compartments from raw message history that Magic Context has captured in that session, such as after upgrading historian rules; it is not an importer for unrelated pre-install OpenCode or Pi sessions. The dashboard can also inspect the shared CortexKit database, memories, compartments, and dreamer runs without starting a coding session.
 
 <details>
 <summary><strong>Compatibility with other context-management plugins</strong></summary>


### PR DESCRIPTION
## Summary

- Clarify how Magic Context behaves when added to an existing OpenCode or Pi project
- State that pre-install sessions are not retroactively imported or backfilled into compartments
- Explain what starts accumulating after installation and when `/ctx-recomp` is appropriate

Closes #76

## Testing

- `git diff --check origin/master...HEAD`
- Docs-only change; package tests were not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783999773&installation_id=135454708&pr_number=147&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F147&signature=3cef19d5774dad224cf48ddb1baa201822b236d4d4c3b324fb19c853e32edeb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies how Magic Context works in existing OpenCode or Pi projects: no retroactive import of pre-install sessions, what starts accumulating after install, when to use `/ctx-recomp`, and how to seed older knowledge. Closes #76.

<sup>Written for commit 5c2172fff04dc7650c350f2f3a6e7cd298049f83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the "Adding Magic Context to an existing project" section of the README to fix a previously misleading statement (closes #76) that implied older raw session history would be summarized as the historian runs. The rewrite explicitly states that pre-install OpenCode/Pi sessions are never imported or backfilled, clarifies what `/ctx-recomp` does and does not do, and provides alternatives for seeding knowledge from older work.

- The old first paragraph suggested "older raw session history is summarized as the historian runs," which was incorrect; the new text replaces this with an accurate description of what accumulates after installation.
- A new paragraph explicitly calls out the no-backfill behaviour and explains manual alternatives (`ctx_memory`, a repo note, or organic accumulation over time).
- The `/ctx-recomp` description is tightened to scope it to Magic Context–captured history only, preventing confusion with pre-install sessions; the `/ctx-dream` mention is dropped from this section (the command is still documented elsewhere).
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no code impact; safe to merge.

The change is entirely in README.md prose. It corrects a factual inaccuracy about historian behaviour and tightens the scope of two commands. The only note is a minor wording ambiguity ("from day one") flagged as a suggestion.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Documentation-only update to the "Adding Magic Context to an existing project" section; corrects the misleading implication that pre-install session history is processed by the historian, explicitly states no backfilling occurs, clarifies `/ctx-recomp` scope, and removes a stale `/ctx-dream` suggestion (the command remains documented elsewhere). |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Wizard as Setup Wizard
    participant MC as Magic Context
    participant Historian
    participant Dreamer

    Note over User: Existing OpenCode / Pi project
    User->>Wizard: npx setup (existing project root)
    Wizard->>MC: Attach to existing project identity
    Note over User,MC: Pre-install sessions — NOT imported or backfilled

    User->>MC: Restart harness
    MC->>Historian: Begin capturing new turns
    Historian->>MC: Compartmentalise active session as it grows
    Dreamer->>MC: Maintain dreamer docs on idle

    alt Seed older knowledge manually
        User->>MC: ctx_memory write (key facts)
        User->>MC: Add project note to repo
    end

    alt Rebuild compartments from captured history
        User->>MC: /ctx-recomp
        MC->>Historian: Rebuild compartments from Magic Context raw history only
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify existing project adoption"](https://github.com/cortexkit/magic-context/commit/5c2172fff04dc7650c350f2f3a6e7cd298049f83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37456777)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->