### PR TITLE
feat(historian): disallow single tools for weak models

### DIFF
--- a/assets/magic-context.schema.json
+++ b/assets/magic-context.schema.json
@@ -181,6 +181,21 @@
             "high",
             "xhigh"
           ]
+        },
+        "disallowed_tools": {
+          "default": [],
+          "description": "OpenCode only. Tools to REMOVE from the historian's default allow-list [read, aft_outline, aft_zoom, aft_search]. Applies to both historian and historian-editor agents. Use [\"*\"] to strip all tool definitions from the model request — this prevents weak instruction-following models (e.g. mistral-small-latest) from entering tool-calling loops. Individual tool names remove just that tool. Note: a user-supplied historian.permission override can re-allow a tool that disallowed_tools removed — disallowed_tools sets the baseline, permission overrides take precedence. (default: [])",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "*",
+              "read",
+              "aft_outline",
+              "aft_zoom",
+              "aft_search"
+            ]
+          }
         }
       }
     },

--- a/packages/dashboard/src/components/ConfigEditor/config-field-coverage.ts
+++ b/packages/dashboard/src/components/ConfigEditor/config-field-coverage.ts
@@ -75,6 +75,7 @@ export const OMITTED_BY_DESIGN: Readonly<Record<string, string>> = {
   "historian.disable":
     "historian is core to magic-context; disabling it is an advanced raw-JSONC choice, not a form toggle",
   "historian.two_pass": "advanced historian tuning; raw JSONC",
+  "historian.disallowed_tools": "advanced historian tuning; raw JSONC",
   "dreamer.max_runtime_minutes": "advanced dreamer scheduling; raw JSONC",
   "dreamer.tasks": "advanced dreamer task list; raw JSONC",
   "dreamer.task_timeout_minutes": "advanced dreamer scheduling; raw JSONC",

--- a/packages/plugin/src/agents/permissions.test.ts
+++ b/packages/plugin/src/agents/permissions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+    applyDisallowedTools,
     buildAllowOnlyPermission,
     DREAMER_ALLOWED_TOOLS,
     HISTORIAN_ALLOWED_TOOLS,
@@ -80,6 +81,47 @@ describe("HISTORIAN_ALLOWED_TOOLS", () => {
         // Repo-wide exploration belongs to dreamer / primary agents.
         expect(HISTORIAN_ALLOWED_TOOLS).not.toContain("grep");
         expect(HISTORIAN_ALLOWED_TOOLS).not.toContain("glob");
+    });
+});
+
+describe("applyDisallowedTools", () => {
+    it("returns the defaults unchanged when disallowed is empty", () => {
+        expect(applyDisallowedTools(HISTORIAN_ALLOWED_TOOLS, [])).toEqual([
+            ...HISTORIAN_ALLOWED_TOOLS,
+        ]);
+    });
+
+    it('removes all tools when "*" is in the disallowed list', () => {
+        expect(applyDisallowedTools(HISTORIAN_ALLOWED_TOOLS, ["*"])).toEqual([]);
+    });
+
+    it('removes all tools when "*" appears alongside other entries', () => {
+        expect(applyDisallowedTools(HISTORIAN_ALLOWED_TOOLS, ["*", "read"])).toEqual([]);
+    });
+
+    it("removes a single tool by name", () => {
+        const result = applyDisallowedTools(HISTORIAN_ALLOWED_TOOLS, ["read"]);
+        expect(result).not.toContain("read");
+        expect(result).toContain("aft_outline");
+        expect(result).toContain("aft_zoom");
+        expect(result).toContain("aft_search");
+    });
+
+    it("removes multiple tools by name", () => {
+        const result = applyDisallowedTools(HISTORIAN_ALLOWED_TOOLS, ["read", "aft_search"]);
+        expect(result).toEqual(["aft_outline", "aft_zoom"]);
+    });
+
+    it("silently ignores unknown tool names (defense-in-depth)", () => {
+        expect(applyDisallowedTools(HISTORIAN_ALLOWED_TOOLS, ["nonexistent"])).toEqual([
+            ...HISTORIAN_ALLOWED_TOOLS,
+        ]);
+    });
+
+    it("produces empty allow-list → buildAllowOnlyPermission yields wildcard deny only", () => {
+        const allowed = applyDisallowedTools(HISTORIAN_ALLOWED_TOOLS, ["*"]);
+        const perm = buildAllowOnlyPermission(allowed);
+        expect(perm).toEqual({ "*": "deny" });
     });
 });
 

--- a/packages/plugin/src/agents/permissions.ts
+++ b/packages/plugin/src/agents/permissions.ts
@@ -109,6 +109,19 @@ export function buildAllowOnlyPermission(
 export const HISTORIAN_ALLOWED_TOOLS = ["read", "aft_outline", "aft_zoom", "aft_search"] as const;
 
 /**
+ * Subtract `disallowed` from the default historian allow-list. `"*"` removes
+ * all tools. Unknown tool names are silently ignored (the Zod enum in the
+ * config schema rejects them at parse time, so this is defense-in-depth).
+ */
+export function applyDisallowedTools(
+    defaults: readonly string[],
+    disallowed: readonly string[],
+): readonly string[] {
+    if (disallowed.includes("*")) return [];
+    return defaults.filter((t) => !disallowed.includes(t));
+}
+
+/**
  * Tools the dreamer agent needs. This is the broadest hidden-agent
  * surface because dreamer's tasks legitimately require local-repo
  * exploration plus external command execution:

--- a/packages/plugin/src/config/schema/magic-context.ts
+++ b/packages/plugin/src/config/schema/magic-context.ts
@@ -144,6 +144,12 @@ export const HistorianConfigSchema = AgentOverrideConfigSchema.extend({
     thinking_level: PiThinkingLevelSchema.describe(
         "Pi only: explicit thinking level passed as --thinking <level> to Pi historian subagent invocations. Required when using reasoning models (e.g. github-copilot/gpt-5.4) because Pi's default thinking-level resolution can pick a value the provider rejects. OpenCode users set variant instead. Valid: off | minimal | low | medium | high | xhigh",
     ),
+    disallowed_tools: z
+        .array(z.enum(["*", "read", "aft_outline", "aft_zoom", "aft_search"]))
+        .default([])
+        .describe(
+            'OpenCode only. Tools to REMOVE from the historian\'s default allow-list [read, aft_outline, aft_zoom, aft_search]. Applies to both historian and historian-editor agents. Use ["*"] to strip all tool definitions from the model request — this prevents weak instruction-following models (e.g. mistral-small-latest) from entering tool-calling loops. Individual tool names remove just that tool. Note: a user-supplied historian.permission override can re-allow a tool that disallowed_tools removed — disallowed_tools sets the baseline, permission overrides take precedence. (default: [])',
+        ),
 }).optional();
 export type HistorianConfig = NonNullable<z.infer<typeof HistorianConfigSchema>>;
 

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -2,6 +2,7 @@ import type { Plugin } from "@opencode-ai/plugin";
 import { DREAMER_AGENT } from "./agents/dreamer";
 import { HISTORIAN_AGENT, HISTORIAN_EDITOR_AGENT } from "./agents/historian";
 import {
+    applyDisallowedTools,
     buildAllowOnlyPermission,
     DREAMER_ALLOWED_TOOLS,
     HISTORIAN_ALLOWED_TOOLS,
@@ -564,15 +565,27 @@ const plugin: Plugin = async (ctx) => {
                       return agentOverrides;
                   })()
                 : undefined;
-            // Strip two_pass from historian overrides — it's consumed by the runner,
-            // not a valid OpenCode agent config field. Both historian and historian-editor
-            // agents use the remaining overrides (same model, fallbacks, etc.).
+            // Strip two_pass + disallowed_tools from historian overrides —
+            // two_pass is consumed by the runner, disallowed_tools is consumed
+            // below to build the permission map. Neither is a valid OpenCode
+            // agent config field. Both historian and historian-editor agents use
+            // the remaining overrides (same model, fallbacks, etc.).
             const historianAgentOverrides = pluginConfig.historian
                 ? (() => {
-                      const { two_pass: _twoPass, ...agentOverrides } = pluginConfig.historian;
+                      const {
+                          two_pass: _twoPass,
+                          disallowed_tools: _disallowedTools,
+                          ...agentOverrides
+                      } = pluginConfig.historian;
                       return agentOverrides;
                   })()
                 : undefined;
+            // Apply disallowed_tools to the default allow-list. "*" removes all.
+            const historianDisallowed = pluginConfig.historian?.disallowed_tools ?? [];
+            const historianAllowedTools = applyDisallowedTools(
+                HISTORIAN_ALLOWED_TOOLS,
+                historianDisallowed,
+            );
 
             config.agent = {
                 ...(config.agent ?? {}),
@@ -596,17 +609,14 @@ const plugin: Plugin = async (ctx) => {
                     // (gated in the runner). Keeping the system prompt constant
                     // preserves prompt-cache byte stability.
                     COMPARTMENT_AGENT_SYSTEM_PROMPT,
-                    HISTORIAN_ALLOWED_TOOLS,
-                    // The historian reads its (often inline) prompt and emits
-                    // compartments — a handful of steps at most; the cap is pure
-                    // loop insurance for a weak model.
+                    historianAllowedTools,
                     HISTORIAN_MAX_STEPS,
                     historianAgentOverrides,
                 ),
                 [HISTORIAN_EDITOR_AGENT]: buildHiddenAgentConfig(
                     HISTORIAN_EDITOR_AGENT,
                     HISTORIAN_EDITOR_SYSTEM_PROMPT,
-                    HISTORIAN_ALLOWED_TOOLS,
+                    historianAllowedTools,
                     HISTORIAN_MAX_STEPS,
                     historianAgentOverrides,
                 ),


### PR DESCRIPTION
Fixes https://github.com/cortexkit/magic-context/issues/166

### What's this about?
Weak instruction-following models (e.g. `mistral-small-latest`) enter tool-calling loops when tool definitions are present in the system prompt, wasting tokens and timing out without producing output. The historian receives its full prompt inline and does not need tools, but the default is preserved for strong models that may benefit from optional symbol verification.

This PR adds `historian.disallowed_tools` to `magic-context.jsonc`. Without changing the default, it removes tools from the default allow-list
- `read`,
- `aft_outline`,
- `aft_zoom`,
- `aft_search`

Use `["*"]` to strip all tool definitions from the model request.

### Config example
```json
"historian": { "disallowed_tools": ["*"] }
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784349318&installation_id=135454708&pr_number=164&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F164&signature=9363f258288e5ba145bd8902eeb6f477aa38a6ed27556da5a8378ec9d3c97e62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `historian.disallowed_tools` to let you remove tools from the historian’s default allow-list, including an option to strip all tools and stop tool-calling loops on weak models like `mistral-small-latest`. Applies to both historian and historian-editor without changing current defaults.

- **New Features**
  - New config in `magic-context.jsonc`: `historian.disallowed_tools` removes tools from the default set [`read`, `aft_outline`, `aft_zoom`, `aft_search`].
  - Support `"*"` to remove all tool definitions from the model request.
  - Unknown tool names are ignored; defaults remain unchanged if the list is empty.

- **Migration**
  - To disable all tools for weak models, set: `"historian": { "disallowed_tools": ["*"] }`.

<sup>Written for commit 080f4123c076c6e1c7418f80dd13def14c569c22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

