### PR TITLE
fix(historian): strip `thinking_level` from OpenCode agent overrides

### DIFF
--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -564,12 +564,17 @@ const plugin: Plugin = async (ctx) => {
                       return agentOverrides;
                   })()
                 : undefined;
-            // Strip two_pass from historian overrides — it's consumed by the runner,
-            // not a valid OpenCode agent config field. Both historian and historian-editor
+            // Strip two_pass + thinking_level from historian overrides — two_pass
+            // is consumed by the runner, thinking_level is Pi-only. Neither is a
+            // valid OpenCode agent config field. Both historian and historian-editor
             // agents use the remaining overrides (same model, fallbacks, etc.).
             const historianAgentOverrides = pluginConfig.historian
                 ? (() => {
-                      const { two_pass: _twoPass, ...agentOverrides } = pluginConfig.historian;
+                      const {
+                          two_pass: _twoPass,
+                          thinking_level: _thinkingLevel,
+                          ...agentOverrides
+                      } = pluginConfig.historian;
                       return agentOverrides;
                   })()
                 : undefined;


### PR DESCRIPTION
Closes #167

## What's this about?
`thinking_level` is a _Pi_-only field (passed as `--thinking <level>` to the Pi subprocess) but was not stripped from the _historian_ agent overrides before passing them to `buildHiddenAgentConfig`.

It leaked into the _OpenCode_ agent config as an unknown key.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784349383&installation_id=135454708&pr_number=165&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F165&signature=68bf721d0f24d63bfce651abbe17d8c1c93bd2e0cf75e0d9c8e5f699275353eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip the Pi-only `thinking_level` from `historian` overrides (alongside `two_pass`) so it doesn’t leak into the OpenCode agent config as an unknown key.

- **Bug Fixes**
  - Omit `thinking_level` and `two_pass` from `pluginConfig.historian` before calling `buildHiddenAgentConfig`; `historian` and `historian-editor` still use the remaining overrides (model, fallbacks, etc.).

<sup>Written for commit 65d45dc89828722ad235c6fd24212e8cc28659e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

