### PR TITLE
fix(tui): null-guard RecompProgressSection against reactive race (#168)

### DIFF
--- a/packages/plugin/src/tui/slots/sidebar-content.tsx
+++ b/packages/plugin/src/tui/slots/sidebar-content.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @opentui/solid */
-import { createEffect, createMemo, createSignal, on, onCleanup } from "solid-js"
+import { Show, createEffect, createMemo, createSignal, on, onCleanup } from "solid-js"
 import type { TuiSlotPlugin, TuiPluginApi, TuiThemeCurrent } from "@opencode-ai/plugin/tui"
 import packageJson from "../../../package.json"
 import { loadSidebarSnapshot, type SidebarSnapshot } from "../data/context-db"
@@ -755,9 +755,11 @@ const SidebarContent = (props: {
                             C:{s()?.compartmentCount ?? 0} Q:{s()?.pendingOpsCount ?? 0} N:{s()?.sessionNoteCount ?? 0}
                         </text>
                     </box>
-                    {s()?.recompProgress && (
-                        <RecompProgressSection theme={props.theme} progress={s()!.recompProgress!} />
-                    )}
+                    <Show when={s()?.recompProgress}>
+                        {(progress) => (
+                            <RecompProgressSection theme={props.theme} progress={progress()} />
+                        )}
+                    </Show>
                 </box>
             )}
 
@@ -789,9 +791,11 @@ const SidebarContent = (props: {
             />
 
             {/* Recomp / session-upgrade live progress */}
-            {s()?.recompProgress && (
-                <RecompProgressSection theme={props.theme} progress={s()!.recompProgress!} />
-            )}
+            <Show when={s()?.recompProgress}>
+                {(progress) => (
+                    <RecompProgressSection theme={props.theme} progress={progress()} />
+                )}
+            </Show>
                 </>
             )}
 


### PR DESCRIPTION
## Summary

Fixes #168 — fatal TUI crash `null is not an object (evaluating 'props.progress.phase')` in `RecompProgressSection`.

Replaces two fragile Solid JSX render sites with the canonical `<Show>` callback form, eliminating a reactive null-deref race that crashed the TUI when the sidebar snapshot transiently published `recompProgress: null` during a recomp pass.

## Root cause

Both render sites of `RecompProgressSection` used this pattern:

```tsx
{s()?.recompProgress && (
    <RecompProgressSection theme={props.theme} progress={s()!.recompProgress!} />
)}
```

The guard reads `s()` with optional chaining (admits null), but the component prop reads `s()!` with non-null assertion (assumes non-null). In Solid, `progress={s()!.recompProgress!}` is re-evaluated on every reactive access of `props.progress` inside the child — this reactivity is intentional (the L356–L363 comment explains the child must observe phase transitions live without remounting). When `setSnapshot({ ...data, recompProgress: null })` is published during a transient cache miss (the resilient poll loop at L540–L606 carries the last good progress forward, but when both current snapshot AND `prevProgress` are falsy, it publishes a null), the next reactive read of `props.progress.phase` dereferences null and crashes.

The `NonNullable<SidebarSnapshot["recompProgress"]>` annotation on the component's `progress` prop is a compile-time promise that nothing enforces at runtime.

## The fix

```tsx
<Show when={s()?.recompProgress}>
    {(progress) => (
        <RecompProgressSection theme={props.theme} progress={progress()} />
    )}
</Show>
```

`<Show>`'s callback form guarantees:
1. The child callback only runs while `when` is truthy.
2. The `progress()` accessor returns the narrowed non-null value reactively.
3. When `when` goes falsy, the callback unmounts — no further reactive accesses to `props.progress` are possible.

Also removes two `noNonNullAssertion` lint warnings.

## Files changed

- `packages/plugin/src/tui/slots/sidebar-content.tsx`
  - Added `Show` to the `solid-js` import.
  - Replaced the collapsed-view render site (L758–L762).
  - Replaced the expanded-view render site (L794–L798).

## Scope

- **In scope:** Eliminate the null-deref crash in the two known render sites of `RecompProgressSection`.
- **Out of scope (noted in #168):** `packages/plugin/biome.json` and `packages/plugin/tsconfig.json` both scope their includes to `src/**/*.ts` and exclude `.tsx`, so type and lint errors in `.tsx` files are not caught by `bun run typecheck` / `bun run lint` in CI. Adding `src/**/*.tsx` to both include lists would prevent this class of bug from shipping. Left for a separate PR per the repo's scope preference.

## Test plan

- [x] `bun run typecheck` — exit 0 (default scope)
- [x] `bun run lint` — exit 0, 494 files checked (default scope)
- [x] `bun run build` — exit 0, 374 modules bundled (bun's transpiler covers `.tsx`)
- [x] `bun run test` — 2103 pass / 0 fail (baseline: 2103 pass / 0 fail)
- [ ] Manual: trigger a `/ctx-recomp` and confirm the progress section still renders live updates without crashing across snapshot cache misses.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784355925&installation_id=135454708&pr_number=169&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F169&signature=faf34474b1ae2f3f990e0a4e6e4f3658234bbd3fab01defe99d991bd22019d80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a TUI crash by switching `RecompProgressSection` to Solid’s <Show> callback so it only renders when `recompProgress` exists. This removes the reactive null-deref that occurred during transient cache misses.

- **Bug Fixes**
  - Replaced both sidebar render sites with <Show when={s()?.recompProgress}>{(progress) => <RecompProgressSection ... progress={progress()} />}</Show> to avoid null derefs and auto-unmount when falsy.
  - Imported `Show` from `solid-js` and removed non-null assertions on the `progress` prop.

<sup>Written for commit a87fa703fe9eb5473e7907490dbf2d371662d09e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

