### PR TITLE
feat(retry): add validateResponse to detect empty model responses and trigger fallback

### DIFF
--- a/packages/plugin/src/features/magic-context/dreamer/runner.ts
+++ b/packages/plugin/src/features/magic-context/dreamer/runner.ts
@@ -386,6 +386,30 @@ export async function runDream(args: {
                         signal: taskAbortController.signal,
                         fallbackModels: args.fallbackModels,
                         callContext: `dreamer:${taskName}`,
+                        validateResponse: async (validateClient, validateSessionId) => {
+                            // Detect empty responses (0 output tokens) that some
+                            // providers return on quota exhaustion with HTTP 200
+                            // instead of a proper error code. Without this, the
+                            // fallback chain is never activated for such responses.
+                            const messagesResponse = await validateClient.session.messages({
+                                path: { id: validateSessionId },
+                                query: {
+                                    directory: args.sessionDirectory ?? args.projectIdentity,
+                                    limit: 50,
+                                },
+                            });
+                            const messages = shared.normalizeSDKResponse(
+                                messagesResponse,
+                                [] as unknown[],
+                                { preferResponseOnMissingData: true },
+                            );
+                            const output = extractLatestAssistantText(messages);
+                            if (!output) {
+                                throw new Error(
+                                    `[dreamer:${taskName}] model returned empty response (0 tokens) — possible quota exhaustion`,
+                                );
+                            }
+                        },
                     },
                 );
                 if (lostLease) {
@@ -859,6 +883,26 @@ Only include notes whose conditions you could definitively evaluate against exte
                 signal: abortController.signal,
                 fallbackModels: args.fallbackModels,
                 callContext: "dreamer:smart-notes",
+                validateResponse: async (validateClient, validateSessionId) => {
+                    const messagesResponse = await validateClient.session.messages({
+                        path: { id: validateSessionId },
+                        query: {
+                            directory: args.sessionDirectory ?? args.projectIdentity,
+                            limit: 50,
+                        },
+                    });
+                    const messages = shared.normalizeSDKResponse(
+                        messagesResponse,
+                        [] as unknown[],
+                        { preferResponseOnMissingData: true },
+                    );
+                    const output = extractLatestAssistantText(messages);
+                    if (!output) {
+                        throw new Error(
+                            "[dreamer:smart-notes] model returned empty response (0 tokens) — possible quota exhaustion",
+                        );
+                    }
+                },
             },
         );
 

--- a/packages/plugin/src/shared/model-suggestion-retry.test.ts
+++ b/packages/plugin/src/shared/model-suggestion-retry.test.ts
@@ -308,4 +308,75 @@ describe("promptSyncWithModelSuggestionRetry", () => {
         ).rejects.toBe(originalError);
         expect(prompt).toHaveBeenCalledTimes(1);
     });
+
+    // --- validateResponse: empty-response detection ---
+
+    test("validateResponse: primary returns empty → fallback[0] succeeds", async () => {
+        const prompt = mock(async () => ({})); // both succeed (HTTP 200)
+        const client = createClient(prompt);
+        const validate = mock(async () => {
+            // primary attempt (call 1): empty → throw
+            if (validate.mock.calls.length === 1) {
+                throw new Error("empty response (0 tokens)");
+            }
+            // fallback attempt (call 2): non-empty → ok
+        });
+
+        await promptSyncWithModelSuggestionRetry(client, createArgs(), {
+            fallbackModels: ["anthropic/claude-sonnet-4-6"],
+            validateResponse: validate,
+        });
+
+        expect(prompt).toHaveBeenCalledTimes(2);
+        expect(validate).toHaveBeenCalledTimes(2);
+        expect((prompt.mock.calls[1]?.[0] as PromptCall).body.model).toEqual({
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-6",
+        });
+    });
+
+    test("validateResponse: all attempts return empty → throws last error", async () => {
+        const prompt = mock(async () => ({}));
+        const client = createClient(prompt);
+        const emptyError = new Error("empty response (0 tokens)");
+        const validate = mock(async () => {
+            throw emptyError;
+        });
+
+        await expect(
+            promptSyncWithModelSuggestionRetry(client, createArgs(), {
+                fallbackModels: ["anthropic/claude-sonnet-4-6", "google/gemini-3-flash"],
+                validateResponse: validate,
+            }),
+        ).rejects.toBe(emptyError);
+
+        expect(prompt).toHaveBeenCalledTimes(3); // primary + 2 fallbacks
+        expect(validate).toHaveBeenCalledTimes(3);
+    });
+
+    test("validateResponse: primary non-empty → no fallback tried", async () => {
+        const prompt = mock(async () => ({}));
+        const client = createClient(prompt);
+        const validate = mock(async () => {}); // always passes
+
+        await promptSyncWithModelSuggestionRetry(client, createArgs(), {
+            fallbackModels: ["anthropic/claude-sonnet-4-6"],
+            validateResponse: validate,
+        });
+
+        expect(prompt).toHaveBeenCalledTimes(1);
+        expect(validate).toHaveBeenCalledTimes(1);
+    });
+
+    test("validateResponse absent → backward compatible", async () => {
+        const prompt = mock(async () => ({}));
+        const client = createClient(prompt);
+
+        await promptSyncWithModelSuggestionRetry(client, createArgs(), {
+            fallbackModels: ["anthropic/claude-sonnet-4-6"],
+            // no validateResponse — legacy behavior
+        });
+
+        expect(prompt).toHaveBeenCalledTimes(1);
+    });
 });

--- a/packages/plugin/src/shared/model-suggestion-retry.ts
+++ b/packages/plugin/src/shared/model-suggestion-retry.ts
@@ -45,6 +45,24 @@ export interface PromptRetryOptions {
      * "subagent" if not provided.
      */
     callContext?: string;
+    /**
+     * Optional validator invoked after each successful prompt attempt (both
+     * the primary and every fallback). If it throws, the error is treated as
+     * retryable — the next fallback model is tried (or the error propagates
+     * if no fallbacks remain).
+     *
+     * Use this to detect "empty response" conditions where the model API
+     * returns HTTP 200 with zero output tokens instead of a proper error
+     * (e.g. shared-quota providers that return empty bodies on quota
+     * exhaustion). Without this validator, such responses are indistinguishable
+     * from success and the fallback chain is never activated — the task
+     * silently fails and only surfaces a post-hoc "no assistant output" error
+     * in the caller's catch block, after the fallback opportunity is lost.
+     *
+     * The validator receives the client and the session ID so it can fetch
+     * messages and inspect the model's output.
+     */
+    validateResponse?: (client: Client, sessionId: string) => Promise<void>;
 }
 
 export interface ModelSuggestionInfo {
@@ -310,6 +328,9 @@ export async function promptSyncWithModelSuggestionRetry(
             callContext,
             explicitPrimaryLabel,
         );
+        if (options.validateResponse) {
+            await options.validateResponse(client, args.path.id);
+        }
         return;
     } catch (error) {
         lastError = error;
@@ -343,6 +364,9 @@ export async function promptSyncWithModelSuggestionRetry(
 
         try {
             await attemptOnce(client, attemptArgs, timeoutMs, options.signal, callContext, label);
+            if (options.validateResponse) {
+                await options.validateResponse(client, args.path.id);
+            }
             log(
                 `[${callContext}] fallback succeeded with ${label} (attempt ${i + 2}/${fallbacks.length + 1})`,
             );


### PR DESCRIPTION
## Summary

Fixes #174.

Some model providers return HTTP 200 with an empty body (0 output tokens) on quota exhaustion instead of a proper error code. `promptSyncWithModelSuggestionRetry` only triggered fallback on thrown exceptions, so these empty responses were treated as success and the fallback chain was never activated — tasks silently failed.

## Changes

### 1. `packages/plugin/src/shared/model-suggestion-retry.ts`

Add an optional `validateResponse` callback to `PromptRetryOptions`:

```typescript
validateResponse?: (client: Client, sessionId: string) => Promise<void>;
```

Invoked after each **successful** prompt attempt (both primary and every fallback). If the validator throws, the error enters the existing catch block and is treated as retryable — the next fallback model is tried.

The validation calls are placed **inside** the existing try blocks, before `return`:

```typescript
try {
    await attemptOnce(/* ... */);
    if (options.validateResponse) {
        await options.validateResponse(client, args.path.id);
    }
    return; // ← only reached if validation passes
} catch (error) {
    lastError = error;
    // ... existing fallback logic ...
}
```

Same pattern for the fallback loop.

### 2. `packages/plugin/src/features/magic-context/dreamer/runner.ts`

Wire `validateResponse` at the two direct `promptSyncWithModelSuggestionRetry` call sites (task runner + smart-notes evaluator). The validator fetches session messages and rejects responses with zero assistant output:

```typescript
validateResponse: async (validateClient, validateSessionId) => {
    const messagesResponse = await validateClient.session.messages({ /* ... */ });
    const messages = shared.normalizeSDKResponse(messagesResponse, [], { /* ... */ });
    const output = extractLatestAssistantText(messages);
    if (!output) {
        throw new Error(`[dreamer:${taskName}] model returned empty response (0 tokens) — possible quota exhaustion`);
    }
},
```

### 3. `packages/plugin/src/shared/model-suggestion-retry.test.ts`

4 new tests covering:
- Primary returns empty → fallback[0] succeeds
- All attempts return empty → throws last error
- Primary non-empty → no fallback tried
- `validateResponse` absent → backward compatible

## Design Decisions

### Why a callback instead of always checking?

Different callers have different definitions of "valid output." A dreamer task needs non-empty assistant text; a summarization task might need a minimum length; a structured-output task might need valid JSON. An opt-in callback lets each caller define its own validation criteria without coupling the retry layer to any specific output format.

### Why not detect empty responses inside `attemptOnce`?

`attemptOnce` doesn't have access to the session query parameters (directory, limit) needed to fetch messages, and adding an unconditional message fetch would penalize all callers — even those that don't need validation. The callback approach adds one extra API call only for callers that opt in.

### Why place the validation inside the try block?

Placing `validateResponse` inside the existing try block means its throw is caught by the existing catch block, which already has the fallback loop logic. The error from `validateResponse` is a plain `Error`, so `isNonRetryable()` returns false → fallback continues. No changes to the catch block were needed.

## Backward Compatibility

Fully backward-compatible. Callers that don't provide `validateResponse` are unaffected — the `if (options.validateResponse)` guard skips the callback entirely.

## Verification

- `bun run typecheck`: 0 errors
- `bun test`: 2166 pass, 0 fail (including 4 new tests)
- `bun run lint`: 0 issues

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784416948&installation_id=135454708&pr_number=175&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F175&signature=307fe6888c6203c1d61000760abbc5581c3d71d7d7edfc9e2bb5b8af147c166d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional response validator to the retry helper to detect HTTP 200 responses with empty outputs and trigger model fallback. Prevents silent failures on quota exhaustion and ensures the fallback chain runs.

- **New Features**
  - Added `validateResponse` to `PromptRetryOptions` in `packages/plugin/src/shared/model-suggestion-retry.ts`; runs after each successful attempt and, if it throws, the next fallback model is tried.
  - Integrated the validator into `packages/plugin/src/features/magic-context/dreamer/runner.ts` for both the task runner and smart-notes; it fetches session messages and rejects when there’s no assistant output.
  - Backward-compatible. Tests in `packages/plugin/src/shared/model-suggestion-retry.test.ts` cover empty→fallback, all-empty→error, non-empty→no fallback, and no-validator behavior.

<sup>Written for commit cdf7ab98bd988fab96bb4c0cf7799d6c50d51677. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

